### PR TITLE
[FEATURE] Context-aware editing

### DIFF
--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Page\AssetCollector;
 use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
@@ -91,6 +92,7 @@ final class PageEditController
         private readonly PolicyRegistry $policyRegistry,
         private readonly Typo3Version $typo3Version,
         private readonly ConnectionPool $connectionPool,
+        private readonly AssetCollector $assetCollector,
     ) {
     }
 
@@ -383,12 +385,28 @@ final class PageEditController
                     $pageUid => 'edit',
                 ],
             ],
+            'module' => 'web_edit',
         ];
 
-        return $buttonBar
-            ->makeLinkButton()
-            ->setHref((string)$this->uriBuilder->buildUriFromRoute('record_edit', $params))
-            ->setTitle($this->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editPageProperties'))
+        if ($this->typo3Version->getMajorVersion() <= 13) {
+            return $buttonBar
+                ->makeLinkButton()
+                ->setHref((string)$this->uriBuilder->buildUriFromRoute('record_edit', $params))
+                ->setTitle($this->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editPageProperties'))
+                ->setIcon($this->iconFactory->getIcon('actions-page-open', IconSize::SMALL));
+        }
+
+        // TODO add this to the Templates/PageEdit.html if TYPO3 v14 is the minimum requirement
+        $this->assetCollector->addJavaScriptModule('@typo3/backend/element/contextual-record-edit-trigger.js');
+
+        // TODO use $this->componentFactory->createGenericButton() if TYPO3 v14 is the minimum requirement
+        return GeneralUtility::makeInstance(GenericButton::class)
+            ->setTag('typo3-backend-contextual-record-edit-trigger')
+            ->setAttributes([
+                'url' => (string)$this->uriBuilder->buildUriFromRoute('record_edit_contextual', $params),
+                'edit-url' => (string)$this->uriBuilder->buildUriFromRoute('record_edit', $params),
+            ])
+            ->setLabel($this->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editPageProperties'))
             ->setIcon($this->iconFactory->getIcon('actions-page-open', IconSize::SMALL));
     }
 
@@ -598,7 +616,8 @@ final class PageEditController
 
         $languageService = $this->getLanguageService();
 
-        $languageDropDownButton = $buttonBar->makeDropDownButton()
+        $languageDropDownButton = $buttonBar
+            ->makeDropDownButton()
             ->setLabel($languageService->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.language'))
             ->setShowLabelText(true);
 

--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -10,6 +10,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use TYPO3\CMS\Backend\Middleware\JavaScriptLabelImportMapEntryResolver;
+use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Context\Context;
@@ -22,7 +23,9 @@ use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Page\Event\ResolveVirtualJavaScriptImportEvent;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\View\ViewFactoryData;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
 use TYPO3\CMS\Frontend\Page\PageInformation;
@@ -31,6 +34,7 @@ use TYPO3\CMS\VisualEditor\Service\DataHandlerService;
 use function array_keys;
 use function implode;
 use function json_decode;
+use function substr;
 
 readonly class PersistenceMiddleware implements MiddlewareInterface
 {
@@ -42,6 +46,7 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
         private FormProtectionFactory $formProtectionFactory,
         private Typo3Version $typo3Version,
         private ListenerProvider $listenerProvider,
+        private PageRenderer $pageRenderer,
     ) {
     }
 
@@ -169,6 +174,31 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             );
         }
 
+        $this->addAjaxSettingsToJS();
+
         return $handler->handle($request);
+    }
+
+    /**
+     * copied from \TYPO3\CMS\Core\Page\PageRenderer::addAjaxUrlsToInlineSettings (v14)
+     */
+    private function addAjaxSettingsToJS(): void
+    {
+        $ajaxUrls = [];
+        // Add the ajax-based routes
+        $router = GeneralUtility::makeInstance(Router::class);
+        foreach ($router->getRoutes() as $routeIdentifier => $route) {
+            if ($route->getOption('ajax')) {
+                $uri = (string)$this->uriBuilder->buildUriFromRoute($routeIdentifier);
+                // use the shortened value in order to use this in JavaScript
+                if (str_starts_with($routeIdentifier, 'ajax_')) {
+                    $routeIdentifier = substr($routeIdentifier, 5);
+                }
+
+                $ajaxUrls[$routeIdentifier] = $uri;
+            }
+        }
+
+        $this->pageRenderer->addInlineSetting(null, 'ajaxUrls', $ajaxUrls);
     }
 }

--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Domain\Record;
 use TYPO3\CMS\Core\Domain\RecordInterface;
 use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Page\AssetCollector;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -34,6 +35,7 @@ final readonly class EditModeService
         private LanguageModeService $languageModeService,
         private LocalizationService $localizationService,
         private FormProtectionFactory $formProtectionFactory,
+        private Typo3Version $typo3Version,
     ) {
     }
 
@@ -57,6 +59,9 @@ final readonly class EditModeService
 
         $this->assetCollector->addStyleSheet('editable', 'EXT:visual_editor/Resources/Public/Css/editable.css');
         $this->assetCollector->addJavaScriptModule('@typo3/visual-editor/Frontend/index');
+        if ($this->typo3Version->getMajorVersion() >= 14) {
+            $this->assetCollector->addJavaScriptModule('@typo3/backend/element/contextual-record-edit-trigger.js');
+        }
 
         $this->loadLanguageLabelsInline();
 
@@ -88,21 +93,25 @@ final readonly class EditModeService
                     'id' => $pageId,
                 ]),
             ]);
-            $editContentUrl = (string)$this->uriBuilder->buildUriFromRoute('record_edit', [
-                'edit' => [
-                    '__TABLE__' => [
-                        '__UID__' => 'edit',
-                    ],
-                ],
+
+            $editParams = [
+                'edit' => ['__TABLE__' => ['__UID__' => 'edit']],
                 'returnUrl' => (string)$this->uriBuilder->buildUriFromRoute('web_edit', [
                     'id' => '__PAGE_ID__',
                 ]),
-            ]);
+                'module' => 'web_edit',
+            ];
+            $editContentUrl = (string)$this->uriBuilder->buildUriFromRoute('record_edit', $editParams);
+            if ($this->typo3Version->getMajorVersion() >= 14) {
+                $editContentContextualUrl = (string)$this->uriBuilder->buildUriFromRoute('record_edit_contextual', $editParams);
+            }
+
             $data = [
                 'pageId' => $pageId,
                 'languageId' => $siteLanguage->getLanguageId(),
                 'newContentUrl' => $newContentUrl,
                 'editContentUrl' => $editContentUrl,
+                'editContentContextualUrl' => $editContentContextualUrl ?? null,
                 'allowNewContent' => $this->languageModeService->getAllowNewContent($pageInformation, $siteLanguage, $request),
                 'token' => $this->formProtectionFactory->createForType('backend')->generateToken('visual_editor', 'save'),
             ];

--- a/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
@@ -27,10 +27,17 @@ export class VeContentElement extends LitElement {
     showElementOverlay: {type: Boolean, attribute: false},
   };
 
-  get editUrl() {
+  get editContentUrl() {
     return window.veInfo.editContentUrl
       .replace('__TABLE__', this.table)
       .replace('__UID__', this.uid)
+      .replace('__PAGE_ID__', this.pid);
+  }
+
+  get editContentContextualUrl() {
+    return window.veInfo.editContentContextualUrl
+      ?.replace('__TABLE__', this.table)
+      ?.replace('__UID__', this.uid)
       .replace('__PAGE_ID__', this.pid);
   }
 
@@ -43,7 +50,7 @@ export class VeContentElement extends LitElement {
       return;
     }
     event.preventDefault();
-    sendMessage('openInMiddleFrame', this.editUrl);
+    sendMessage('openInMiddleFrame', this.editContentUrl);
   }
 
   async _toggleHidden() {
@@ -146,9 +153,23 @@ export class VeContentElement extends LitElement {
                 ${this.canBeMoved ? '⠿ ' : ''}${this.elementName}
               </span>
         <!-- TODO extract button bar as separate component -->
-        <a class="button" href="${this.editUrl}" @click="${this._openEdit}">
-          <ve-icon name="actions-open"/>
-        </a>
+        ${
+          this.editContentContextualUrl
+            ? html`
+              <typo3-backend-contextual-record-edit-trigger
+                url="${this.editContentContextualUrl}"
+                edit-url="${this.editContentUrl}"
+                class="button"
+              >
+                <ve-icon name="actions-open"/>
+              </typo3-backend-contextual-record-edit-trigger>
+            `
+            : html`
+              <a class="button" href="${this.editContentUrl}" @click="${this._openEdit}">
+                <ve-icon name="actions-open"/>
+              </a>
+            `
+        }
         ${
           this.hiddenFieldName ?
             html`


### PR DESCRIPTION
Using the newly introduced typo3-backend-contextual-record-edit-trigger, we now have a side panel overlay to edit page and content properties.

Can be merged after: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93039 has been merged