### PR TITLE
[SECURITY] Validate postMessage origin and source in iframe messaging

### DIFF
--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 use TYPO3\CMS\VisualEditor\Service\LocalizationService;
@@ -37,6 +38,7 @@ final readonly class EditModeService
         private LocalizationService $localizationService,
         private FormProtectionFactory $formProtectionFactory,
         private Typo3Version $typo3Version,
+        private SiteFinder $siteFinder,
     ) {
     }
 
@@ -123,6 +125,7 @@ final readonly class EditModeService
                 'allowNewContent' => $this->languageModeService->getAllowNewContent($pageInformation, $siteLanguage, $request),
                 'token' => $this->formProtectionFactory->createForType('backend')->generateToken('visual_editor', 'save'),
                 'routeArguments' => (object)$this->flattenBracketKeys(['params' => $routing->getRouteArguments()]),
+                'allowedReferrer' => $this->getAllowedReferrer(),
             ];
             $this->assetCollector->addInlineJavaScript(
                 'veLangInfo',
@@ -219,5 +222,25 @@ window.veInfo = ' . json_encode($veInfo, JSON_THROW_ON_ERROR) . ';',
         foreach ($languageService->getLabelsFromResource($file) as $key => $value) {
             $this->pageRenderer->addInlineLanguageLabel($key, $value);
         }
+    }
+
+    /**
+     * returns the origins of all configured sites and languages
+     * @return list<string>
+     */
+    private function getAllowedReferrer(): array
+    {
+        $allowedReferrers = [];
+        $sites = $this->siteFinder->getAllSites();
+        foreach ($sites as $site) {
+            $origin = $site->getBase()->withQuery('')->withPath('')->withUserInfo('')->withFragment('');
+            $allowedReferrers[(string)$origin] = true;
+            foreach ($site->getLanguages() as $language) {
+                $origin = $language->getBase()->withQuery('')->withPath('')->withUserInfo('')->withFragment('');
+                $allowedReferrers[(string)$origin] = true;
+            }
+        }
+
+        return array_keys($allowedReferrers);
     }
 }

--- a/Resources/Public/JavaScript/Shared/iframe-messaging.js
+++ b/Resources/Public/JavaScript/Shared/iframe-messaging.js
@@ -26,19 +26,16 @@ export const isDirectMode = window.parent === window;
 function getPeerOrigin() {
   const editorIframe = document.querySelector('iframe#visual-editor-iframe');
   if (editorIframe) {
-    try {
-      return new URL(editorIframe.src, window.location.href).origin;
-    } catch {
-      return window.location.origin;
-    }
+    return new URL(editorIframe.src, window.location.href).origin;
   }
+
   if (document.referrer) {
-    try {
-      return new URL(document.referrer).origin;
-    } catch {
-      return window.location.origin;
+    const origin = new URL(document.referrer).origin;
+    if (window.veInfo.allowedReferrer.includes(origin)) {
+      return origin;
     }
   }
+
   return window.location.origin;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "b13/container": "^3.2.2",
     "pluswerk/grumphp-config": "^10.2.6",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
-    "ssch/typo3-rector": "^3.12.1",
+    "ssch/typo3-rector": "^3.13.0",
     "typo3fluid/fluid": "^4.6.0 || 4.6.x-dev || ^5"
   },
   "suggest": {


### PR DESCRIPTION
## Summary

The `postMessage` bridge in `iframe-messaging.js` trusted any sender and used `'*'` as target origin. This allowed any embedded third-party iframe on an edited page to drive backend actions such as `openInMiddleFrame`, `reloadFrames`, `closeModal`, and `doSave`.

### Changes

- **Target origin restriction**: `postMessage()` calls now specify the actual peer origin instead of `'*'`
- **Origin validation**: incoming messages are rejected unless `event.origin` matches the expected peer origin
- **Source validation**: incoming messages are rejected unless `event.source` matches the expected peer window (`editorIframe.contentWindow` on the backend side, `window.parent` on the iframe side)
- **Cross-domain support**: the peer origin is derived from `iframe.src` (parent side) and `document.referrer` (child side), preserving compatibility with multi-domain setups where backend and frontend run on different hosts

### Residual note

Child-to-parent origin detection relies on `document.referrer`. If a deployment enforces `Referrer-Policy: no-referrer`, cross-origin messaging will fail closed (safe default). A future hardening option would be to pass the backend origin explicitly (e.g. via query parameter or bootstrapped config).