### PR TITLE
[BUGFIX] Merge save operations into single DataHandler call

### DIFF
--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -77,11 +77,18 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             throw new RuntimeException('Unknown data operations: ' . implode(', ', array_keys($input)) . ' only data and cmdArray are allowed', 8110225095);
         }
 
-        $this->dataHandlerService->run($data, []);
-
+        $mergedCmd = [];
         foreach ($cmdArray as $cmd) {
-            $this->dataHandlerService->run([], $cmd);
+            foreach ($cmd as $table => $records) {
+                foreach ($records as $uid => $actions) {
+                    foreach ($actions as $action => $actionData) {
+                        $mergedCmd[$table][$uid][$action] = $actionData;
+                    }
+                }
+            }
         }
+
+        $this->dataHandlerService->run($data, $mergedCmd);
 
         return new JsonResponse(['success' => true]);
     }


### PR DESCRIPTION
Closes #10

Merges all data and command arrays into one DataHandler invocation instead of running them in separate instances.