### PR TITLE
[FEATURE] Share backend login across domains

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ ij_smart_tabs = false
 ij_visual_guides = 120,160
 ij_wrap_on_typing = false
 
+[*.md]
+trim_trailing_whitespace = false
+
 [*.css]
 ij_css_align_closing_brace_with_properties = false
 ij_css_blank_lines_around_nested_selector = 1

--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -52,6 +52,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
+use TYPO3\CMS\VisualEditor\Service\SessionTransferService;
 
 use function array_map;
 use function array_values;
@@ -93,6 +94,7 @@ final class PageEditController
         private readonly Typo3Version $typo3Version,
         private readonly ConnectionPool $connectionPool,
         private readonly AssetCollector $assetCollector,
+        private readonly SessionTransferService $sessionTransferService,
     ) {
     }
 
@@ -174,18 +176,13 @@ final class PageEditController
             $view->getDocHeaderComponent()->setPageBreadcrumb($this->pageRecord->getRawRecord()->toArray());
         }
 
-        $iframeUrl = $this->iframeUrl($request);
+        $siteLanguage = $this->selectedLanguages[0];
+        $iframeUrl = $this->iframeUrl($request, $siteLanguage);
+
         $view->assignMultiple([
             'pageId' => $this->pageRecord->getUid(),
             'iframeSrc' => $iframeUrl,
         ]);
-
-        $returnUrl = GeneralUtility::sanitizeLocalUrl(
-            (string)($request->getQueryParams()['returnUrl'] ?? ''),
-        ) ?: $this->uriBuilder->buildUriFromRoute('web_edit');
-
-        // Always add rootPageId as additional field to have a reference for new records
-        $view->assign('returnUrl', $returnUrl);
 
         $this->makeButtons($view, $request);
         $this->makeLanguageMenu($view, $request);
@@ -200,14 +197,28 @@ final class PageEditController
         return $view->renderResponse('PageEdit');
     }
 
-    private function iframeUrl(ServerRequestInterface $request): UriInterface
+    private function iframeUrl(ServerRequestInterface $request, SiteLanguage $siteLanguage): UriInterface
     {
+        $token = null;
+        if ($request->getHeaderLine('X-NoToken') === '') {
+            $origin = $this->site->getRouter()->generateUri(
+                $this->pageRecord->getUid(),
+                [
+                    ...$request->getQueryParams()['params'] ?? [],
+                    '_language' => $siteLanguage,
+                    'editMode' => 1,
+                ],
+            );
+            $token = $this->sessionTransferService->createSessionTransferTokenIfNeeded($origin, $request);
+        }
+
         return $this->site->getRouter()->generateUri(
             $this->pageRecord->getUid(),
             [
                 ...$request->getQueryParams()['params'] ?? [],
-                '_language' => $this->selectedLanguages[0]->getLanguageId(),
+                '_language' => $siteLanguage,
                 'editMode' => 1,
+                'token' => $token,
             ],
         );
     }

--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\Cookie;
 use TYPO3\CMS\Backend\Middleware\JavaScriptLabelImportMapEntryResolver;
 use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -21,15 +22,21 @@ use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Page\Event\ResolveVirtualJavaScriptImportEvent;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\View\ViewFactoryData;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 use TYPO3\CMS\VisualEditor\Service\DataHandlerService;
+use TYPO3\CMS\VisualEditor\Service\SessionTransferService;
+use UnexpectedValueException;
 
 use function array_keys;
 use function implode;
@@ -47,6 +54,7 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
         private Typo3Version $typo3Version,
         private ListenerProvider $listenerProvider,
         private PageRenderer $pageRenderer,
+        private SessionTransferService $sessionTransferService,
     ) {
     }
 
@@ -96,6 +104,14 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
 
         // backend user required
         $user = $this->context->getAspect('backend.user');
+
+        if (!empty($params['token'])) {
+            $cookie = $this->sessionTransferService->createCookieIfNeeded($request, $params['token']);
+            if ($cookie) {
+                // session is different to what it should be, update session cookie and reload:
+                $this->setSessionCookie($request, $cookie);
+            }
+        }
 
         if (!$user->isLoggedIn()) {
             $loginUrl = $this->uriBuilder->buildUriFromRoute('login', referenceType: UriBuilder::ABSOLUTE_URL)->__toString();
@@ -200,5 +216,35 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
         }
 
         $this->pageRenderer->addInlineSetting('', 'ajaxUrls', $ajaxUrls);
+    }
+
+    private function setSessionCookie(ServerRequestInterface $request, Cookie $cookie): never
+    {
+        // recreate URI without token (to recreate chash)
+        $site = $request->getAttribute('site');
+        if (!$site instanceof Site) {
+            throw new UnexpectedValueException('"site" not found in request attributes', 9890374333);
+        }
+
+        $routing = $request->getAttribute('routing');
+        if (!$routing instanceof PageArguments) {
+            throw new UnexpectedValueException('"routing" not found in request attributes', 9890374334);
+        }
+
+        $language = $request->getAttribute('language');
+        if (!$language instanceof SiteLanguage) {
+            throw new UnexpectedValueException('"language" not found in request attributes', 9890374335);
+        }
+
+        $uri = $site->getRouter()->generateUri($routing->getPageId(), [
+            'type' => $routing->getPageType(),
+            '_language' => $language,
+            ...$routing->getArguments(),
+            'token' => null,
+        ]);
+
+        $response = new RedirectResponse($uri);
+        $response = $response->withAddedHeader('Set-Cookie', (string)$cookie);
+        throw new ImmediateResponseException($response, 1773838679);
     }
 }

--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -22,9 +22,10 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Page\PageInformation;
-use TYPO3\CMS\VisualEditor\Service\LocalizationService;
 
 use function method_exists;
+
+use const JSON_UNESCAPED_SLASHES;
 
 final readonly class EditModeService
 {
@@ -128,9 +129,9 @@ final readonly class EditModeService
                 'allowedReferrer' => $this->getAllowedReferrer(),
             ];
             $this->assetCollector->addInlineJavaScript(
-                'veLangInfo',
+                'veInfo',
                 'window.TYPO3 = window.TYPO3 || {};
-window.veInfo = ' . json_encode($veInfo, JSON_THROW_ON_ERROR) . ';',
+window.veInfo = ' . json_encode($veInfo, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES) . ';',
                 [
                     'type' => 'text/javascript',
                 ],

--- a/Classes/Service/SessionTransferService.php
+++ b/Classes/Service/SessionTransferService.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\Service;
+
+use Exception;
+use Firebase\JWT\ExpiredException;
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Error\Http\UnauthorizedException;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\SetCookieService;
+use TYPO3\CMS\Core\Security\JwtTrait;
+use TYPO3\CMS\Core\Session\UserSession;
+use TYPO3\CMS\Core\Session\UserSessionManager;
+
+use function array_values;
+use function hash_equals;
+
+/**
+ * SessionTransferTokens are one time use,
+ */
+final readonly class SessionTransferService
+{
+    use JwtTrait;
+
+    /**
+     * returns the session cookie if it needs to be set/updated
+     */
+    public function createCookieIfNeeded(ServerRequestInterface $request, string $sessionTransferToken): ?Cookie
+    {
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        if (!$normalizedParams instanceof NormalizedParams) {
+            throw new Exception('NormalizedParams not found in request attributes', 9890374332);
+        }
+
+        $sessionId = $this->getSessionIdentifier($sessionTransferToken, $request);
+        // you have given a valid sessionTransferToken, so we can create the cookie with confidence
+
+        if (($GLOBALS['BE_USER'] ?? null)?->getSession()?->getIdentifier() === $sessionId) {
+            // we already have the correct session, we only consume the Token and then do nothing.
+            $this->consumeToken($this->getBackendUserAuthentication()->getSession(), $sessionTransferToken);
+            return null;
+        }
+
+        // load session from different origin:
+        $userSession = UserSessionManager::create('BE')->createSessionFromStorage($sessionId);
+
+        // check and consume token or throw Exception
+        $userSession = $this->consumeToken($userSession, $sessionTransferToken);
+
+        // recreate userSession to set markAsNew = true, otherwise we can not use setSessionCookie
+        $userSession = UserSession::createFromRecord($userSession->getIdentifier(), $userSession->toArray(), true);
+
+        $setCookieService = SetCookieService::create(BackendUserAuthentication::getCookieName(), 'BE');
+
+        return $setCookieService->setSessionCookie($userSession, $normalizedParams)
+            ?? throw new Exception('Failed to create session cookie', 1958548954);
+    }
+
+    public function createSessionTransferTokenIfNeeded(UriInterface $allowedOrigin, ServerRequestInterface $request): ?string
+    {
+        if ($this->getOriginFromUri($allowedOrigin) === $this->getOriginFromUri($request->getUri())) {
+            return null;
+        }
+
+        $backendUserAuthentication = $this->getBackendUserAuthentication();
+        $session = $backendUserAuthentication->getSession();
+        $token = self::encodeHashSignedJwt(
+            [
+                // wrap sessionId into new JWT so it can not be used as value for be_typo_user cookie
+                'identifier' => $session->getIdentifier(),
+                // only allow setting the session for this origin:
+                'allowedOrigin' => $this->getOriginFromUri($allowedOrigin),
+                // only allow for the same client IP:
+                'allowedClientIp' => $this->getClientIp($request),
+                // low timeout of the JWT to ensure it is only valid for a short time and reduces the risk of token leakage:
+                'exp' => time() + 10,
+            ],
+            self::createSigningKeyFromEncryptionKey(SessionTransferService::class),
+        );
+
+        // keep track of the created token, to make then one time use
+        $tokens = $this->loadTransferTokens($session);
+        $tokens[] = $token;
+        $backendUserAuthentication->setAndSaveSessionData('SessionTransferTokens', $tokens);
+        return $token;
+    }
+
+    private function getSessionIdentifier(string $token, ServerRequestInterface $request): string
+    {
+        // validates JWT with private key and validates low timeout of the JWT
+        $payload = self::decodeJwt($token, self::createSigningKeyFromEncryptionKey(SessionTransferService::class));
+
+        // compare allowedOrigin with current Origin.
+        if (!hash_equals($payload->allowedOrigin ?? '', $this->getOriginFromUri($request->getUri()))) {
+            throw new UnauthorizedException('Origin not allowed', 9620233479);
+        }
+
+        // compare allowedClientIp with current clientIp
+        if (!hash_equals($payload->allowedClientIp ?? '', $this->getClientIp($request))) {
+            throw new UnauthorizedException('Client IP not allowed', 3530698687);
+        }
+
+        return $payload->identifier ?? throw new Exception('Session identifier not found in request attributes', 8796121015);
+    }
+
+    private function getClientIp(ServerRequestInterface $request): string
+    {
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        if (!$normalizedParams instanceof NormalizedParams) {
+            throw new InvalidArgumentException('"normalizedParams" not found in request attributes', 1772441095);
+        }
+
+        return $normalizedParams->getRemoteAddress();
+    }
+
+    private function getOriginFromUri(UriInterface $allowedOrigin): string
+    {
+        return $allowedOrigin->withQuery('')->withFragment('')->withUserInfo('')->withPath('')->__toString();
+    }
+
+    private function getBackendUserAuthentication(): BackendUserAuthentication
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            throw new InvalidArgumentException('No backend user found', 7146700018);
+        }
+
+        return $backendUser;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function loadTransferTokens(UserSession $session): array
+    {
+        $result = [];
+        foreach ($session->get('SessionTransferTokens') ?? [] as $token) {
+            try {
+                self::decodeJwt($token, self::createSigningKeyFromEncryptionKey(SessionTransferService::class));
+            } catch (ExpiredException) {
+                // token is expired, remove it from the list of valid tokens
+                continue;
+            }
+
+            $result[] = $token;
+        }
+
+        return $result;
+    }
+
+    private function consumeToken(UserSession $userSession, string $sessionTransferToken): UserSession
+    {
+        $validTokens = $this->loadTransferTokens($userSession);
+        foreach ($validTokens as $index => $token) {
+            if (!hash_equals($token, $sessionTransferToken)) {
+                continue;
+            }
+
+            // token is valid, we now remove it from the list of valid tokens to prevent reuse
+            unset($validTokens[$index]);
+            // can not use BackendUserAuthentication->setAndSaveSessionData here, because the session is a different one
+            $userSession->set('SessionTransferTokens', array_values($validTokens));
+            return UserSessionManager::create('BE')->updateSession($userSession);
+        }
+
+        throw new UnauthorizedException('Invalid token was already consumed', 5646002872);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ search for:
   ````html
   before:
   <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{colPos: '3'}"/>
-  
+
   after:
   <f:mark.contentArea colPos="3">
     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{colPos: '3'}"/>
@@ -124,7 +124,7 @@ search for:
   ````html
   before:
   <v:content.render column="0"/>
-  
+
   after:
   <f:mark.contentArea colPos="0">
     <v:content.render column="0"/>
@@ -134,18 +134,12 @@ search for:
   ````html
   before:
   <flux:content.render area="column0"/>
-  
+
   after:
   <f:mark.contentArea colPos="{data.uid}00">
     <flux:content.render area="column0"/>
   </f:mark.contentArea>
   ````
-
-## Multi Site/Domain Setup
-
-You need to be Logged in to every Domain separately to use the Visual Editor.
-
-OR you can use [EXT:multisite_belogin](https://extensions.typo3.org/extension/multisite_belogin) it automatically logs you in to all sites/domains.
 
 ## License and Authors: License type, contributors, contact information
 

--- a/Resources/Public/JavaScript/Backend/page-changed.js
+++ b/Resources/Public/JavaScript/Backend/page-changed.js
@@ -69,7 +69,12 @@ async function loadModuleDocHeader(newUrl) {
   abortController = new AbortController();
   let response;
   try {
-    response = await fetch(newUrl, {signal: abortController.signal});
+    response = await fetch(newUrl, {
+      signal: abortController.signal,
+      headers: {
+        'X-NoToken': '1',
+      },
+    });
     if (!response.ok) {
       console.error('No doc header found.');
       return;

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "typo3/cms-rte-ckeditor": "^13.4.22 || ^14.2.0 || 14.2.x-dev"
   },
   "require-dev": {
-    "b13/container": "^3.2.2",
+    "b13/container": "^3.2.3",
     "pluswerk/grumphp-config": "^10.2.6",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
     "ssch/typo3-rector": "^3.13.0",


### PR DESCRIPTION
Introduce a session transfer token to propagate the active backend session to requests on other domains. The middleware restores the session cookie from the token and redirects the request with the correct backend session.

This improves the editor experience by avoiding additional logins during cross-domain editing.

related: #19, #12 


## TODOs:
- [x] add origin binding for `SessionTransferToken` (to only allow specific domains)
- [x] add clientIp binding
- [x] make `SessionTransferToken` single use
- [x] strip token for the redirect in `PersistenceMiddleware::setSessionCookie`
- [x] gracefully ignore expired handoff tokens instead of crashing
- [x] check if cross-origin works even with `BE[cookieSameSite]=strict`