### PR TITLE
[BUGFIX] Keep visual editor preview same-origin

### DIFF
--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -52,6 +52,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
+use TYPO3\CMS\VisualEditor\ExpressionLanguage\RequestConditionProvider;
 
 use function array_map;
 use function array_values;
@@ -174,18 +175,12 @@ final class PageEditController
             $view->getDocHeaderComponent()->setPageBreadcrumb($this->pageRecord->getRawRecord()->toArray());
         }
 
-        $iframeUrl = $this->iframeUrl($request);
+        $siteLanguage = $this->selectedLanguages[0];
+        $iframeUrl = $this->iframeUrl($request, $siteLanguage);
         $view->assignMultiple([
             'pageId' => $this->pageRecord->getUid(),
             'iframeSrc' => $iframeUrl,
         ]);
-
-        $returnUrl = GeneralUtility::sanitizeLocalUrl(
-            (string)($request->getQueryParams()['returnUrl'] ?? ''),
-        ) ?: $this->uriBuilder->buildUriFromRoute('web_edit');
-
-        // Always add rootPageId as additional field to have a reference for new records
-        $view->assign('returnUrl', $returnUrl);
 
         $this->makeButtons($view, $request);
         $this->makeLanguageMenu($view, $request);
@@ -200,16 +195,40 @@ final class PageEditController
         return $view->renderResponse('PageEdit');
     }
 
-    private function iframeUrl(ServerRequestInterface $request): UriInterface
+    private function iframeUrl(ServerRequestInterface $request, SiteLanguage $siteLanguage): UriInterface
     {
-        return $this->site->getRouter()->generateUri(
-            $this->pageRecord->getUid(),
-            [
-                ...$request->getQueryParams()['params'] ?? [],
-                '_language' => $this->selectedLanguages[0]->getLanguageId(),
-                'editMode' => 1,
-            ],
-        );
+        $parameters = [
+            ...$request->getQueryParams()['params'] ?? [],
+            '_language' => $siteLanguage->getLanguageId(),
+            'editMode' => 1,
+        ];
+
+        $uri = $this->site->getRouter()->generateUri($this->pageRecord->getUid(), $parameters);
+
+        if (
+            $uri->getScheme() === $request->getUri()->getScheme()
+            && $uri->getHost() === $request->getUri()->getHost()
+            && $uri->getPort() === $request->getUri()->getPort()
+        ) {
+            // if same origin, we do not need to use the preview url
+            return $uri;
+        }
+
+        RequestConditionProvider::$forceGeneration = true;
+        try {
+            $siteWithVePreview = new Site(
+                $this->site->getIdentifier(),
+                $this->site->getRootPageId(),
+                $this->site->getConfiguration(),
+                $this->site->getSettings(),
+                $this->site->getTypoScript(),
+                $this->site->getTSconfig(),
+            );
+        } finally {
+            RequestConditionProvider::$forceGeneration = false;
+        }
+
+        return $siteWithVePreview->getRouter()->generateUri($this->pageRecord->getUid(), $parameters);
     }
 
     private function makeButtons(ModuleTemplate $view, ServerRequestInterface $request): void

--- a/Classes/EventListener/SiteConfigurationLoadedEventListener.php
+++ b/Classes/EventListener/SiteConfigurationLoadedEventListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Configuration\Event\SiteConfigurationLoadedEvent;
+
+use function array_unshift;
+use function rtrim;
+
+final readonly class SiteConfigurationLoadedEventListener
+{
+    #[AsEventListener]
+    public function __invoke(SiteConfigurationLoadedEvent $event): void
+    {
+        $id = $event->getSiteIdentifier();
+        $configuration = $event->getConfiguration();
+        $configuration['baseVariants'] ??= [];
+
+
+        array_unshift($configuration['baseVariants'], [
+            'base' => '/ve-preview/' . $id . '/',
+            'condition' => 'isVePreview',
+        ]);
+
+        if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix'])) {
+            array_unshift($configuration['baseVariants'], [
+                'base' => rtrim((string) $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix'], '/') . '/ve-preview/' . $id . '/',
+                'condition' => 'isVePreviewReverseProxyPrefix',
+            ]);
+        }
+
+        if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL'])) {
+            array_unshift($configuration['baseVariants'], [
+                'base' => rtrim((string) $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL'], '/') . '/ve-preview/' . $id . '/',
+                'condition' => 'isVePreviewReverseProxyPrefixSSL',
+            ]);
+        }
+
+        foreach ($configuration['languages'] as $key => $language) {
+            $configuration['languages'][$key]['baseVariants'] ??= [];
+            array_unshift($configuration['languages'][$key]['baseVariants'], [
+                'base' => '/' . $language['languageId'] . '/',
+                'condition' => 'isVePreview',
+            ]);
+        }
+
+        $event->setConfiguration($configuration);
+    }
+}

--- a/Classes/ExpressionLanguage/RequestConditionProvider.php
+++ b/Classes/ExpressionLanguage/RequestConditionProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\ExpressionLanguage;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\ExpressionLanguage\AbstractProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function str_starts_with;
+
+final class RequestConditionProvider extends AbstractProvider
+{
+    public static bool $forceGeneration = false;
+
+    public function __construct()
+    {
+        if (empty($_SERVER['REQUEST_METHOD'])) {
+            // only change the base Urls if it is a request.
+            return;
+        }
+
+        if (empty($_COOKIE[BackendUserAuthentication::getCookieName()])) {
+            // only change the base Urls if backend user cookie is set. (reduce duplicate content in SEO)
+            return;
+        }
+
+        $prefix = '';
+        // Add a prefix if TYPO3 is behind a proxy: ext-domain.com => int-server.com/prefix
+        if (
+            isset($_SERVER['REMOTE_ADDR'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'])
+            && GeneralUtility::cmpIP($_SERVER['REMOTE_ADDR'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'])
+        ) {
+            if (GeneralUtility::getIndpEnv('TYPO3_SSL') && !empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL'])) {
+                $prefix = $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL'];
+                $isVePreviewReverseProxyPrefixSSL = true;
+            } elseif (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix'])) {
+                $prefix = $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix'];
+                $isVePreviewReverseProxyPrefix = true;
+            }
+        }
+
+        if (!self::$forceGeneration && !str_starts_with((string)GeneralUtility::getIndpEnv('REQUEST_URI'), rtrim((string) $prefix, '/') . '/ve-preview/')) {
+            // only change the base Urls if requested
+            return;
+        }
+
+        $this->expressionLanguageVariables = [
+            'isVePreviewReverseProxyPrefixSSL' => $isVePreviewReverseProxyPrefixSSL ?? false,
+            'isVePreviewReverseProxyPrefix' => $isVePreviewReverseProxyPrefix ?? false,
+            'isVePreview' => true,
+        ];
+    }
+}

--- a/Configuration/ExpressionLanguage.php
+++ b/Configuration/ExpressionLanguage.php
@@ -1,0 +1,9 @@
+<?php
+
+use TYPO3\CMS\VisualEditor\ExpressionLanguage\RequestConditionProvider;
+
+return [
+    'site' => [
+        RequestConditionProvider::class,
+    ]
+];


### PR DESCRIPTION
Reuse the regular page URL for the editor iframe when frontend and backend already share scheme, host and port. If the page would be rendered on a different origin, generate a dedicated /ve-preview/{site}/ URL instead and respect language variants as well as reverse-proxy prefixes.

The visual editor needs reliable access to the iframe document. Keeping the preview same-origin avoids browser restrictions, makes backend sessions usable in multi-domain setups and only falls back to the custom preview route when that extra indirection is actually required.

This approach will solve every cross-origin problem as it eliminates cross-origin completely. 
This makes the implementation for Visual Editor much easier. It also has the same backend user session as approach #20, but without the security concerns of transferring the backend session to a different domain.

However, it could cause problems for custom code that checks for the domain instead of relying on standard site-based configuration.

closes #19, closes #20
resolves #12

TODOs:
- [ ] remove `suggest.wapplersystems/multisite-belogin` from `composer.json`
- [ ] make optional, if option is disabled, only show link to the correct backend