### PR TITLE
[BUGFIX] Exclude default RTE contents CSS from visual editor frontend

### DIFF
--- a/Classes/ViewHelpers/Render/TextViewHelper.php
+++ b/Classes/ViewHelpers/Render/TextViewHelper.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Core\Schema\Field\InputFieldType;
 use TYPO3\CMS\Core\Schema\Field\TextFieldType;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Fluid\ViewHelpers\Format\HtmlViewHelper;
 use TYPO3\CMS\Frontend\Page\PageInformation;
@@ -31,6 +32,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 use function get_debug_type;
 use function htmlspecialchars;
+use function is_array;
 use function is_string;
 use function json_encode;
 use function nl2br;
@@ -51,6 +53,8 @@ use const JSON_THROW_ON_ERROR;
 final class TextViewHelper extends AbstractViewHelper
 {
     private const RECORD_TYPE = RecordInterface::class . '|' . PageInformation::class . '|' . DomainObjectInterface::class;
+
+    private const DEFAULT_RTE_CONTENTS_CSS_RESOURCE = 'EXT:rte_ckeditor/Resources/Public/Css/contents.css';
 
     /**
      * Extbase models have a __toString() method and Fluid calls that if we escape the Children (arguments)
@@ -262,6 +266,23 @@ final class TextViewHelper extends AbstractViewHelper
         );
 
         $config = $this->richTextConfigurationService->resolveCkEditorConfiguration($richTextConfigurationServiceDto);
+        if (is_array($config['contentsCss'] ?? null)) {
+            $defaultRteContentsCss = PathUtility::getAbsoluteWebPath(
+                GeneralUtility::createVersionNumberedFilename(
+                    GeneralUtility::getFileAbsFileName(self::DEFAULT_RTE_CONTENTS_CSS_RESOURCE),
+                ),
+            );
+            $contentsCss = [];
+            foreach ($config['contentsCss'] as $path) {
+                if (is_string($path) && $path === $defaultRteContentsCss) {
+                    continue;
+                }
+
+                $contentsCss[] = $path;
+            }
+
+            $config['contentsCss'] = $contentsCss;
+        }
 
         unset($config['height']); // height is set by the content itself and css
         $config['debug'] = false; // for now we disable debug mode

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "typo3/cms-rte-ckeditor": "^13.4.22 || ^14.2.0 || 14.2.x-dev"
   },
   "require-dev": {
-    "b13/container": "^3.2.2",
+    "b13/container": "^3.2.3",
     "pluswerk/grumphp-config": "^10.2.6",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
     "ssch/typo3-rector": "^3.13.0",


### PR DESCRIPTION
Do not load TYPO3's default `EXT:rte_ckeditor/Resources/Public/Css/contents.css` in the visual editor frontend.

The frontend output should keep using the regular frontend CSS as its styling base. Only custom RTE CSS files should remain, so project-specific editor styling is added where the normal frontend CSS does not already cover it.