### PR TITLE
[BUGFIX] Clean up component listeners on disconnect

### DIFF
--- a/Resources/Public/JavaScript/Backend/components/ve-auto-save-toggle.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-auto-save-toggle.js
@@ -34,24 +34,26 @@ export class VeAutoSaveToggle extends LitElement {
     super();
     this.count = 0;
     this.label = this.innerText;
+    this.disposeChangeListener = null;
+    this.onClick = this.#onClick.bind(this);
+  }
 
-    onMessageDebounced('change', (count) => {
-      this.count = count;
-      if (this.active && this.count > 0) {
-        sendMessage('doSave');
-      }
-    }, 300);
+  connectedCallback() {
+    super.connectedCallback();
 
-    this.addEventListener('click', (e) => {
-      e.preventDefault();
-      this.active = !this.active;
+    if (!this.disposeChangeListener) {
+      this.disposeChangeListener = onMessageDebounced('change', this.#onChangeMessage.bind(this), 300);
+    }
 
-      autoSaveActive.set(this.active);
+    this.addEventListener('click', this.onClick);
+  }
 
-      if (this.active && this.count > 0) {
-        sendMessage('doSave');
-      }
-    })
+  disconnectedCallback() {
+    this.disposeChangeListener?.();
+    this.disposeChangeListener = null;
+    this.removeEventListener('click', this.onClick);
+
+    super.disconnectedCallback();
   }
 
   render() {
@@ -59,6 +61,24 @@ export class VeAutoSaveToggle extends LitElement {
     return html`
       <typo3-backend-icon identifier="${icon}" size="small"></typo3-backend-icon>
       ${(this.label)}`;
+  }
+
+  #onChangeMessage(count) {
+    this.count = count;
+    if (this.active && this.count > 0) {
+      sendMessage('doSave');
+    }
+  }
+
+  #onClick(e) {
+    e.preventDefault();
+    this.active = !this.active;
+
+    autoSaveActive.set(this.active);
+
+    if (this.active && this.count > 0) {
+      sendMessage('doSave');
+    }
   }
 
   static styles = css`

--- a/Resources/Public/JavaScript/Backend/components/ve-backend-save-button.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-backend-save-button.js
@@ -24,27 +24,37 @@ export class VeBackendSaveButton extends LitElement {
     this.count = 0;
     this.saving = false;
     this.disabled = true;
+    this.disposeUpdateChangesCountListener = null;
+    this.disposeOnSaveListener = null;
+    this.disposeSaveEndedListener = null;
+  }
 
-    onMessage('updateChangesCount', (count) => {
-      this.count = count;
-    });
+  connectedCallback() {
+    super.connectedCallback();
 
-    onMessage('onSave', () => {
-      this.saving = true;
-    });
+    if (!this.disposeUpdateChangesCountListener) {
+      this.disposeUpdateChangesCountListener = onMessage('updateChangesCount', this.onUpdateChangesCount.bind(this));
+    }
+    if (!this.disposeOnSaveListener) {
+      this.disposeOnSaveListener = onMessage('onSave', this.onSaveMessage.bind(this));
+    }
+    if (!this.disposeSaveEndedListener) {
+      this.disposeSaveEndedListener = onMessage('saveEnded', this.onSaveEndedMessage.bind(this));
+    }
 
-    onMessage('saveEnded', ({updatePageTree}) => {
-      this.saving = false;
+    this.addEventListener('click', this.onClick);
+  }
 
-      if (updatePageTree) {
-        console.log('Updating page tree after save', {updatePageTree});
-        top.document.dispatchEvent(new CustomEvent('typo3:pagetree:refresh'));
-      }
-    });
-    this.addEventListener('click', (e) => {
-      e.preventDefault();
-      sendMessage('doSave');
-    })
+  disconnectedCallback() {
+    this.disposeUpdateChangesCountListener?.();
+    this.disposeUpdateChangesCountListener = null;
+    this.disposeOnSaveListener?.();
+    this.disposeOnSaveListener = null;
+    this.disposeSaveEndedListener?.();
+    this.disposeSaveEndedListener = null;
+    this.removeEventListener('click', this.onClick);
+
+    super.disconnectedCallback();
   }
 
   render() {
@@ -59,6 +69,28 @@ export class VeBackendSaveButton extends LitElement {
       <typo3-backend-icon identifier="actions-save" size="small"></typo3-backend-icon>
       ${label}
     `;
+  }
+
+  onUpdateChangesCount(count) {
+    this.count = count;
+  }
+
+  onSaveMessage() {
+    this.saving = true;
+  }
+
+  onSaveEndedMessage({updatePageTree}) {
+    this.saving = false;
+
+    if (updatePageTree) {
+      console.log('Updating page tree after save', {updatePageTree});
+      top.document.dispatchEvent(new CustomEvent('typo3:pagetree:refresh'));
+    }
+  }
+
+  onClick(e) {
+    e.preventDefault();
+    sendMessage('doSave');
   }
 
 

--- a/Resources/Public/JavaScript/Backend/components/ve-show-empty-toggle.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-show-empty-toggle.js
@@ -23,17 +23,22 @@ export class VeShowEmptyToggle extends LitElement {
     this.innerHTML = '';
     this.active = showEmptyActive.get();
     sendMessage('showEmpty', this.active);
+    this.onShowEmptyChange = this.#onShowEmptyChange.bind(this);
+    this.onClick = this.#onClick.bind(this);
+  }
 
-    showEmptyActive.addEventListener('change', () => {
-      this.active = showEmptyActive.get();
-    });
-    this.addEventListener('click', (e) => {
-      e.preventDefault();
+  connectedCallback() {
+    super.connectedCallback();
 
-      this.active = !this.active;
-      showEmptyActive.set(this.active);
-      sendMessage('showEmpty', this.active);
-    })
+    showEmptyActive.addEventListener('change', this.onShowEmptyChange);
+    this.addEventListener('click', this.onClick);
+  }
+
+  disconnectedCallback() {
+    showEmptyActive.removeEventListener('change', this.onShowEmptyChange);
+    this.removeEventListener('click', this.onClick);
+
+    super.disconnectedCallback();
   }
 
   willUpdate(changedProperties) {
@@ -47,6 +52,18 @@ export class VeShowEmptyToggle extends LitElement {
       <typo3-backend-icon identifier="${this.active ? 'actions-eye' : 'actions-hyphen'}" size="small"></typo3-backend-icon>
       ${this.label}
     `;
+  }
+
+  #onShowEmptyChange() {
+    this.active = showEmptyActive.get();
+  }
+
+  #onClick(e) {
+    e.preventDefault();
+
+    this.active = !this.active;
+    showEmptyActive.set(this.active);
+    sendMessage('showEmpty', this.active);
   }
 }
 

--- a/Resources/Public/JavaScript/Backend/components/ve-spotlight-toggle.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-spotlight-toggle.js
@@ -22,17 +22,22 @@ export class VeSpotlightToggle extends LitElement {
     this.label = this.innerText;
     this.innerHTML = '';
     this.active = spotlightActive.get();
+    this.onSpotlightChange = this.#onSpotlightChange.bind(this);
+    this.onClick = this.#onClick.bind(this);
+  }
 
-    spotlightActive.addEventListener('change', () => {
-      this.active = spotlightActive.get();
-    });
+  connectedCallback() {
+    super.connectedCallback();
 
-    this.addEventListener('click', (e) => {
-      e.preventDefault();
+    spotlightActive.addEventListener('change', this.onSpotlightChange);
+    this.addEventListener('click', this.onClick);
+  }
 
-      this.active = !this.active;
-      spotlightActive.set(this.active);
-    })
+  disconnectedCallback() {
+    spotlightActive.removeEventListener('change', this.onSpotlightChange);
+    this.removeEventListener('click', this.onClick);
+
+    super.disconnectedCallback();
   }
 
   willUpdate(changedProperties) {
@@ -46,6 +51,17 @@ export class VeSpotlightToggle extends LitElement {
       <typo3-backend-icon identifier="${this.active ? 'actions-lightbulb-on' : 'actions-lightbulb'}" size="small"></typo3-backend-icon>
       ${this.label}
     `;
+  }
+
+  #onSpotlightChange() {
+    this.active = spotlightActive.get();
+  }
+
+  #onClick(e) {
+    e.preventDefault();
+
+    this.active = !this.active;
+    spotlightActive.set(this.active);
   }
 }
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-content-area.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-content-area.js
@@ -19,10 +19,19 @@ export class VeContentArea extends LitElement {
   constructor() {
     super();
     // observe child changes and rerender this component
-    const observer = new MutationObserver(() => {
-      this.requestUpdate();
-    });
-    observer.observe(this, {childList: true});
+    this.observer = new MutationObserver(() => this.requestUpdate());
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.observer.observe(this, {childList: true});
+  }
+
+  disconnectedCallback() {
+    this.observer?.disconnect();
+
+    super.disconnectedCallback();
   }
 
   firstUpdated(changedProperties) {

--- a/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
@@ -74,23 +74,35 @@ export class VeContentElement extends LitElement {
 
   constructor() {
     super();
+    this.onDragInProgressChange = this.#onDragInProgressChange.bind(this);
+  }
 
-    dragInProgressStore.addEventListener('change', () => {
-      if (!dragInProgressStore.value) {
-        this.dragInProgress = false;
-      }
-      setTimeout(() => {
-        // delay the dragInProgress set to true, so the drag handle can be "screenshot". (to create the drag ghost image) (otherwise the drag will immediately end in chromium based browsers)
-        this.dragInProgress = !!dragInProgressStore.value;
-      });
+  connectedCallback() {
+    super.connectedCallback();
 
-    });
+    dragInProgressStore.addEventListener('change', this.onDragInProgressChange);
 
     if (this.parentElement.tagName.toLowerCase() !== 've-content-area') {
       let message = 'parent of ve-content-element must be ve-content-area, found ' + this.parentElement.tagName.toLowerCase();
       message += "\n" + 'drag and drop is disabled for this element.';
       console.warn(message);
     }
+  }
+
+  disconnectedCallback() {
+    dragInProgressStore.removeEventListener('change', this.onDragInProgressChange);
+
+    super.disconnectedCallback();
+  }
+
+  #onDragInProgressChange() {
+    if (!dragInProgressStore.value) {
+      this.dragInProgress = false;
+    }
+    setTimeout(() => {
+      // delay the dragInProgress set to true, so the drag handle can be "screenshot". (to create the drag ghost image) (otherwise the drag will immediately end in chromium based browsers)
+      this.dragInProgress = !!dragInProgressStore.value;
+    });
   }
 
   get hasContentAreaAsParent() {

--- a/Resources/Public/JavaScript/Frontend/components/ve-drag-handle.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-drag-handle.js
@@ -15,26 +15,36 @@ export class VeDragHandle extends LitElement {
 
   constructor() {
     super();
+    this.onDragStart = this.#dragStart.bind(this);
+    this.onDragEnd = this.#dragEnd.bind(this);
+  }
 
+  connectedCallback() {
+    super.connectedCallback();
+
+    if (this.isActive === 'true') {
+      this.setAttribute('draggable', 'true');
+      this.addEventListener('dragstart', this.onDragStart);
+      this.addEventListener('dragend', this.onDragEnd);
+    }
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('dragstart', this.onDragStart);
+    this.removeEventListener('dragend', this.onDragEnd);
+
+    super.disconnectedCallback();
   }
 
   firstUpdated(changedProperties) {
     autoNoOverlap(this, 've-drag-handle');
     this.style.paddingBottom = 'calc(var(--auto-no-overlap-padding, 0px) + 4px)';
-
-    if (this.isActive === 'true') {
-      /** @type {HTMLElement} */
-      const element = this;
-      element.setAttribute('draggable', 'true');
-      element.addEventListener('dragstart', this._dragStart.bind(this));
-      element.addEventListener('dragend', this._dragEnd.bind(this));
-    }
   }
 
   /**
    * @param {DragEvent} event
    */
-  _dragStart(event) {
+  #dragStart(event) {
     event.dataTransfer.effectAllowed = 'copyMove';
     event.dataTransfer.clearData();
 
@@ -51,7 +61,7 @@ export class VeDragHandle extends LitElement {
   /**
    * @param {DragEvent} event
    */
-  _dragEnd(event) {
+  #dragEnd(event) {
     dragInProgressStore.value = false;
   }
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-drop-zone.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-drop-zone.js
@@ -98,14 +98,20 @@ export class VeDropZone extends LitElement {
   constructor() {
     super();
     this.isDragHovering = false;
+    this.onDragInProgressChange = this.#onDragInProgressChange.bind(this);
+  }
 
-    dragInProgressStore.addEventListener('change', () => {
-      const newValue = this.shouldShow();
-      if (this.show !== newValue) {
-        setTimeout(calculateAllDebounced);
-      }
-      this.show = newValue;
-    });
+  connectedCallback() {
+    super.connectedCallback();
+
+    dragInProgressStore.addEventListener('change', this.onDragInProgressChange);
+  }
+
+  disconnectedCallback() {
+    dragInProgressStore.removeEventListener('change', this.onDragInProgressChange);
+    this.dragOverTimeout && clearTimeout(this.dragOverTimeout);
+
+    super.disconnectedCallback();
   }
 
   firstUpdated(changedProperties) {
@@ -217,6 +223,14 @@ export class VeDropZone extends LitElement {
         flipInsertBefore(firstParent, sourceElement, firstParent.firstChild);
         return;
     }
+  }
+
+  #onDragInProgressChange() {
+    const newValue = this.shouldShow();
+    if (this.show !== newValue) {
+      setTimeout(calculateAllDebounced);
+    }
+    this.show = newValue;
   }
 
   render() {

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
@@ -36,22 +36,26 @@ export class VeEditableRichText extends LitElement {
   constructor() {
     super();
     this.value = this.innerHTML;
-    dataHandlerStore.addEventListener('change', () => {
-      this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
-      const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
-      if (storedValue?.trim() !== this.editor?.getData({ skipListItemIds: true })?.trim()) {
-        this.value = storedValue ?? this.value;
-        this.editor?.setData(this.value);
-      }
-    })
     this.showEmpty = showEmptyActive.get();
-    showEmptyActive.addEventListener('change', () => {
-      this.showEmpty = showEmptyActive.get();
-    });
-    // disable drop while dragging content elements
-    dragInProgressStore.addEventListener('change', () => {
-      this.style.pointerEvents = dragInProgressStore.value ? 'none' : '';
-    });
+    this.onDataHandlerChange = this.#onDataHandlerChange.bind(this);
+    this.onShowEmptyChange = this.#onShowEmptyChange.bind(this);
+    this.onDragInProgressChange = this.#onDragInProgressChange.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    dataHandlerStore.addEventListener('change', this.onDataHandlerChange);
+    showEmptyActive.addEventListener('change', this.onShowEmptyChange);
+    dragInProgressStore.addEventListener('change', this.onDragInProgressChange);
+  }
+
+  disconnectedCallback() {
+    dataHandlerStore.removeEventListener('change', this.onDataHandlerChange);
+    showEmptyActive.removeEventListener('change', this.onShowEmptyChange);
+    dragInProgressStore.removeEventListener('change', this.onDragInProgressChange);
+
+    super.disconnectedCallback();
   }
 
   async firstUpdated() {
@@ -145,6 +149,23 @@ export class VeEditableRichText extends LitElement {
    */
   async hash(input) {
     return new Uint8Array(await crypto.subtle.digest('SHA-1', new TextEncoder().encode(input))).toHex();
+  }
+
+  #onDataHandlerChange() {
+    this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
+    const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
+    if (storedValue?.trim() !== this.editor?.getData({ skipListItemIds: true })?.trim()) {
+      this.value = storedValue ?? this.value;
+      this.editor?.setData(this.value);
+    }
+  }
+
+  #onShowEmptyChange() {
+    this.showEmpty = showEmptyActive.get();
+  }
+
+  #onDragInProgressChange() {
+    this.style.pointerEvents = dragInProgressStore.value ? 'none' : '';
   }
 }
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -27,35 +27,44 @@ export class VeEditableText extends LitElement {
     this.value = this.getAttribute('value');
     this.valueInitial = this.value;
     this.innerText = '';
-    this.addEventListener('click', (e) => {
-      e.stopPropagation();
-    })
-    this.addEventListener('mousedown', (e) => {
-      e.stopPropagation();
-    })
-    this.addEventListener('pointerdown', (e) => {
-      e.stopPropagation();
-    })
-    this.addEventListener('dragstart', (e) => {
-      e.stopPropagation();
-      e.preventDefault();
-    })
     this.showEmpty = showEmptyActive.get();
-    showEmptyActive.addEventListener('change', () => {
-      this.showEmpty = showEmptyActive.get();
-    });
-    dataHandlerStore.addEventListener('change', () => {
-      this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
-      this.valueInitial = dataHandlerStore.initialData[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
-      const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
-      const slot = this.shadowRoot?.querySelector('.slot');
-      if (storedValue?.trim() !== slot?.innerText?.trim()) {
-        this.value = storedValue ?? this.value;
-        if (slot) {
-          slot.innerText = this.value;
-        }
-      }
-    })
+    this.onClick = this.#onClick.bind(this);
+    this.onMousedown = this.#onMousedown.bind(this);
+    this.onPointerdown = this.#onPointerdown.bind(this);
+    this.onDragstart = this.#onDragstart.bind(this);
+    this.onMouseover = this.#onMouseover.bind(this);
+    this.onMouseout = this.#onMouseout.bind(this);
+    this.onContextmenu = this.#onContextmenu.bind(this);
+    this.onShowEmptyChange = this.#onShowEmptyChange.bind(this);
+    this.onDataHandlerChange = this.#onDataHandlerChange.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.addEventListener('click', this.onClick);
+    this.addEventListener('mousedown', this.onMousedown);
+    this.addEventListener('pointerdown', this.onPointerdown);
+    this.addEventListener('dragstart', this.onDragstart);
+    this.addEventListener('mouseover', this.onMouseover);
+    this.addEventListener('mouseout', this.onMouseout);
+    this.addEventListener('contextmenu', this.onContextmenu);
+    showEmptyActive.addEventListener('change', this.onShowEmptyChange);
+    dataHandlerStore.addEventListener('change', this.onDataHandlerChange);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this.onClick);
+    this.removeEventListener('mousedown', this.onMousedown);
+    this.removeEventListener('pointerdown', this.onPointerdown);
+    this.removeEventListener('dragstart', this.onDragstart);
+    this.removeEventListener('mouseover', this.onMouseover);
+    this.removeEventListener('mouseout', this.onMouseout);
+    this.removeEventListener('contextmenu', this.onContextmenu);
+    showEmptyActive.removeEventListener('change', this.onShowEmptyChange);
+    dataHandlerStore.removeEventListener('change', this.onDataHandlerChange);
+
+    super.disconnectedCallback();
   }
 
   /**
@@ -63,50 +72,8 @@ export class VeEditableText extends LitElement {
    */
   firstUpdated(changedProperties) {
     this.placeholder = '👀' + (this.placeholder || this.title);
-    this.#initHandleLinkClick();
     this.shadowRoot.querySelector('.slot').innerText = this.valueInitial || '';
     dataHandlerStore.setInitialData(this.table, this.uid, this.field, this.valueInitial);
-  }
-
-  #initHandleLinkClick() {
-    const aTag = this.closest('a');
-    if (!(aTag instanceof HTMLAnchorElement)) {
-      return;
-    }
-    aTag.dataset.veHref = aTag.href;
-
-    // remove the href if the text is hovered.
-    this.addEventListener('mouseover', () => aTag.removeAttribute('href'));
-    // add the href back when the mouse leaves the text.
-    this.addEventListener('mouseout', () => aTag.href = aTag.dataset.veHref);
-
-    // on right-click on the text, we want to open the context menu for the link, so we need to add the href back before the context menu opens, and remove it again after.
-    this.addEventListener('contextmenu', () => {
-      aTag.href = aTag.dataset.veHref;
-      setTimeout(() => aTag.removeAttribute('href'));
-    });
-
-    // on middle-click or ctrl/cmd + left click, we want to open the link
-    // we want to open the link in the same tab, even if it has target="_blank"
-    // we do that because otherwise you can not open the link in the same tab.
-    // you can still open the link in a new tab by right-clicking and choosing "open link in new tab"
-    this.addEventListener('mousedown', (e) => {
-      const ctrlPressed = e.ctrlKey || e.metaKey;
-      const middleClick = e.button === 1;
-      if (ctrlPressed || middleClick) {
-        e.preventDefault();
-        aTag.href = aTag.dataset.veHref;
-
-        const target = aTag.target;
-        aTag.target = '_self';
-        aTag.click();
-
-        setTimeout(() => {
-          aTag.target = target;
-          aTag.removeAttribute('href');
-        });
-      }
-    });
   }
 
   updated(changedProperties) {
@@ -194,6 +161,92 @@ export class VeEditableText extends LitElement {
 
     // if there are other child nodes, we should be inline
     return childNodes.length > 1;
+  }
+
+  #getClosestAnchor() {
+    const aTag = this.closest('a');
+    if (!(aTag instanceof HTMLAnchorElement)) {
+      return null;
+    }
+    aTag.dataset.veHref = aTag.dataset.veHref || aTag.href;
+    return aTag;
+  }
+
+  #onClick(e) {
+    e.stopPropagation();
+  }
+
+  #onMousedown(e) {
+    e.stopPropagation();
+
+    const aTag = this.#getClosestAnchor();
+    if (!aTag) {
+      return;
+    }
+
+    const ctrlPressed = e.ctrlKey || e.metaKey;
+    const middleClick = e.button === 1;
+    if (ctrlPressed || middleClick) {
+      e.preventDefault();
+      aTag.href = aTag.dataset.veHref;
+
+      const target = aTag.target;
+      aTag.target = '_self';
+      aTag.click();
+
+      setTimeout(() => {
+        aTag.target = target;
+        aTag.removeAttribute('href');
+      });
+    }
+  }
+
+  #onPointerdown(e) {
+    e.stopPropagation();
+  }
+
+  #onDragstart(e) {
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
+  #onMouseover() {
+    const aTag = this.#getClosestAnchor();
+    aTag?.removeAttribute('href');
+  }
+
+  #onMouseout() {
+    const aTag = this.#getClosestAnchor();
+    if (aTag) {
+      aTag.href = aTag.dataset.veHref;
+    }
+  }
+
+  #onContextmenu() {
+    const aTag = this.#getClosestAnchor();
+    if (!aTag) {
+      return;
+    }
+
+    aTag.href = aTag.dataset.veHref;
+    setTimeout(() => aTag.removeAttribute('href'));
+  }
+
+  #onShowEmptyChange() {
+    this.showEmpty = showEmptyActive.get();
+  }
+
+  #onDataHandlerChange() {
+    this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
+    this.valueInitial = dataHandlerStore.initialData[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
+    const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
+    const slot = this.shadowRoot?.querySelector('.slot');
+    if (storedValue?.trim() !== slot?.innerText?.trim()) {
+      this.value = storedValue ?? this.value;
+      if (slot) {
+        slot.innerText = this.value;
+      }
+    }
   }
 
   static styles = css`

--- a/Resources/Public/JavaScript/Frontend/components/ve-save-button.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-save-button.js
@@ -17,32 +17,30 @@ export class VeSaveButton extends LitElement {
     super();
     this.saving = false;
     this.count = 0;
+    this.disposeDoSaveListener = null;
+    this.onDataHandlerChange = this.#onDataHandlerChange.bind(this);
+    this.onKeydown = this.#onKeydown.bind(this);
+    this.onDoSaveMessage = this.#onDoSaveMessage.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
     sendMessage('updateChangesCount', this.count);
+    dataHandlerStore.addEventListener('change', this.onDataHandlerChange);
+    document.addEventListener('keydown', this.onKeydown);
+    if (!this.disposeDoSaveListener) {
+      this.disposeDoSaveListener = onMessage('doSave', this.onDoSaveMessage);
+    }
+  }
 
-    dataHandlerStore.addEventListener('change', () => {
-      sendMessage('change', dataHandlerStore.changesCount);
-      if (dataHandlerStore.changesCount === this.count) {
-        return;
-      }
-      this.count = dataHandlerStore.changesCount;
+  disconnectedCallback() {
+    dataHandlerStore.removeEventListener('change', this.onDataHandlerChange);
+    document.removeEventListener('keydown', this.onKeydown);
+    this.disposeDoSaveListener?.();
+    this.disposeDoSaveListener = null;
 
-      sendMessage('updateChangesCount', this.count);
-    });
-
-    document.addEventListener('keydown', (event) => {
-      // on CTRL + S
-      if (!((event.ctrlKey || event.metaKey) && event.key === 's')) {
-        return;
-      }
-
-      event.preventDefault();
-
-      this.trySave();
-    });
-
-    onMessage('doSave', () => {
-      this.trySave();
-    });
+    super.disconnectedCallback();
   }
 
   trySave() {
@@ -94,6 +92,29 @@ export class VeSaveButton extends LitElement {
         ${label}
       </button>
     `;
+  }
+
+  #onDataHandlerChange() {
+    sendMessage('change', dataHandlerStore.changesCount);
+    if (dataHandlerStore.changesCount === this.count) {
+      return;
+    }
+    this.count = dataHandlerStore.changesCount;
+
+    sendMessage('updateChangesCount', this.count);
+  }
+
+  #onKeydown(event) {
+    if (!((event.ctrlKey || event.metaKey) && event.key === 's')) {
+      return;
+    }
+
+    event.preventDefault();
+    this.trySave();
+  }
+
+  #onDoSaveMessage() {
+    this.trySave();
   }
 
 

--- a/Resources/Public/JavaScript/Shared/iframe-messaging.js
+++ b/Resources/Public/JavaScript/Shared/iframe-messaging.js
@@ -77,8 +77,10 @@ let isMessageListenerInitialized = false;
  * @param callback {(detail: VECommandDetailMap[K]) => void}
  */
 export function onMessage(command, callback) {
-  messageListeners[`ve_${command}`] = messageListeners[`ve_${command}`] || [];
-  messageListeners[`ve_${command}`].push(callback);
+  const listenerKey = `ve_${command}`;
+
+  messageListeners[listenerKey] = messageListeners[listenerKey] || [];
+  messageListeners[listenerKey].push(callback);
   if (!isMessageListenerInitialized) {
     isMessageListenerInitialized = true;
 
@@ -98,6 +100,23 @@ export function onMessage(command, callback) {
       }
     });
   }
+
+  return () => {
+    const listeners = messageListeners[listenerKey];
+    if (!listeners) {
+      return;
+    }
+
+    const index = listeners.indexOf(callback);
+    if (index === -1) {
+      return;
+    }
+
+    listeners.splice(index, 1);
+    if (listeners.length === 0) {
+      delete messageListeners[listenerKey];
+    }
+  };
 }
 
 /**
@@ -114,7 +133,12 @@ export function onMessageDebounced(command, callback, delay = 300) {
       callback(detail);
     }, delay);
   };
-  onMessage(command, debouncedCallback);
+  const unsubscribe = onMessage(command, debouncedCallback);
+
+  return () => {
+    clearTimeout(timeoutId);
+    unsubscribe();
+  };
 }
 
 /**
@@ -122,5 +146,5 @@ export function onMessageDebounced(command, callback, delay = 300) {
  * @param command {K}
  */
 export function stopListeningMessages(command) {
-  delete messageListeners[command];
+  delete messageListeners[`ve_${command}`];
 }


### PR DESCRIPTION
Move component-scoped listeners and observers into lifecycle-managed setup and teardown across the JavaScript components.

Detached custom elements previously kept reacting to store changes, postMessage events, and DOM events after they had been removed. That caused stale callbacks to stay alive, made re-attachment behavior inconsistent, and left `ve-auto-save-toggle` still reacting to debounced `change` messages after removal.

Add per-listener unsubscribe support to iframe messaging and deregister component listeners in `disconnectedCallback()` so listener lifetime matches component lifetime.

fixes #24 