### PR TITLE
[BUGFIX] remove cross-origin issues in visual editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /var/
 /vendor/
 /composer.lock

--- a/Classes/Backend/Controller/CrossOriginNavigationController.php
+++ b/Classes/Backend/Controller/CrossOriginNavigationController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\Backend\Controller;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\VisualEditor\Service\CrossOriginNavigationResolver;
+
+#[AsController]
+final readonly class CrossOriginNavigationController
+{
+    public function __construct(
+        private CrossOriginNavigationResolver $resolver,
+    ) {
+    }
+
+    public function resolveBackendUrlAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $payload = $request->getParsedBody();
+        if (!is_array($payload)) {
+            $payload = json_decode((string)$request->getBody(), true);
+        }
+
+        $frontendUrl = is_array($payload) ? (string)($payload['url'] ?? '') : '';
+        if ($frontendUrl === '') {
+            return new JsonResponse(['error' => 'Missing url'], 400);
+        }
+
+        try {
+            return new JsonResponse([
+                'url' => $this->resolver->resolveBackendUrl($frontendUrl),
+            ]);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            return new JsonResponse(['error' => $invalidArgumentException->getMessage()], 400);
+        }
+    }
+}

--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -30,6 +30,8 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Domain\Record;
 use TYPO3\CMS\Core\Domain\RecordFactory;
+use TYPO3\CMS\Core\Http\HtmlResponse;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -60,6 +62,8 @@ use function count;
 use function in_array;
 use function is_array;
 use function sprintf;
+
+use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @phpstan-type LanguageRef -1|0|positive-int
@@ -174,18 +178,12 @@ final class PageEditController
             $view->getDocHeaderComponent()->setPageBreadcrumb($this->pageRecord->getRawRecord()->toArray());
         }
 
-        $iframeUrl = $this->iframeUrl($request);
+        $siteLanguage = $this->selectedLanguages[0];
+        $iframeUrl = $this->iframeUrl($request, $siteLanguage);
         $view->assignMultiple([
             'pageId' => $this->pageRecord->getUid(),
             'iframeSrc' => $iframeUrl,
         ]);
-
-        $returnUrl = GeneralUtility::sanitizeLocalUrl(
-            (string)($request->getQueryParams()['returnUrl'] ?? ''),
-        ) ?: $this->uriBuilder->buildUriFromRoute('web_edit');
-
-        // Always add rootPageId as additional field to have a reference for new records
-        $view->assign('returnUrl', $returnUrl);
 
         $this->makeButtons($view, $request);
         $this->makeLanguageMenu($view, $request);
@@ -200,16 +198,40 @@ final class PageEditController
         return $view->renderResponse('PageEdit');
     }
 
-    private function iframeUrl(ServerRequestInterface $request): UriInterface
+    private function iframeUrl(ServerRequestInterface $request, SiteLanguage $siteLanguage): UriInterface
     {
-        return $this->site->getRouter()->generateUri(
-            $this->pageRecord->getUid(),
-            [
-                ...$request->getQueryParams()['params'] ?? [],
-                '_language' => $this->selectedLanguages[0]->getLanguageId(),
-                'editMode' => 1,
-            ],
-        );
+        $parameters = [
+            ...$request->getQueryParams()['params'] ?? [],
+            '_language' => $siteLanguage->getLanguageId(),
+            'editMode' => 1,
+        ];
+
+        $uri = $this->site->getRouter()->generateUri($this->pageRecord->getUid(), $parameters);
+
+        if (
+            $uri->getScheme() === $request->getUri()->getScheme()
+            && $uri->getHost() === $request->getUri()->getHost()
+            && $uri->getPort() === $request->getUri()->getPort()
+        ) {
+            // if same origin, we can return the Uri
+            return $uri;
+        }
+
+        // redirect to the correct backend origin:
+        $backendUrl = $this->uriBuilder
+            ->buildUriFromRoute(
+                'web_edit',
+                [
+                    'id' => $this->pageRecord->getUid(),
+                    'languages' => array_map(fn(SiteLanguage $siteLanguage): int => $siteLanguage->getLanguageId(), $this->selectedLanguages),
+                ],
+                referenceType: UriBuilder::ABSOLUTE_URL,
+            )
+            ->withScheme($uri->getScheme())
+            ->withHost($uri->getHost())
+            ->withPort($uri->getPort());
+        $html = '<script>window.top.location.href = ' . json_encode((string)$backendUrl, JSON_UNESCAPED_SLASHES) . ';</script>';
+        throw new ImmediateResponseException(new HtmlResponse($html, 406), 3234807219);
     }
 
     private function makeButtons(ModuleTemplate $view, ServerRequestInterface $request): void

--- a/Classes/Service/CrossOriginNavigationResolver.php
+++ b/Classes/Service/CrossOriginNavigationResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\Service;
+
+use Throwable;
+use InvalidArgumentException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Routing\RouteNotFoundException;
+use TYPO3\CMS\Core\Routing\SiteMatcher;
+use TYPO3\CMS\Core\Routing\SiteRouteResult;
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+final readonly class CrossOriginNavigationResolver
+{
+    public function __construct(
+        private SiteMatcher $siteMatcher,
+        private UriBuilder $uriBuilder,
+    ) {
+    }
+
+    public function resolveBackendUrl(string $frontendUrl): string
+    {
+        $uri = new Uri($frontendUrl);
+
+        parse_str($uri->getQuery(), $queryParams);
+        $frontendRequest = (new ServerRequest($uri))->withQueryParams($queryParams);
+        try {
+            /** @var SiteRouteResult $siteMatch */
+            $siteMatch = $this->siteMatcher->matchRequest($frontendRequest);
+        } catch (Throwable $throwable) {
+            throw new InvalidArgumentException('Could not resolve target site', 1742900105, $throwable);
+        }
+
+        $site = $siteMatch->getSite();
+        if (!($site instanceof Site)) {
+            throw new InvalidArgumentException('Target URL does not belong to a TYPO3 site', 1742900102);
+        }
+
+        try {
+            $route = $site->getRouter()->matchRequest($frontendRequest, $siteMatch);
+        } catch (RouteNotFoundException $routeNotFoundException) {
+            throw new InvalidArgumentException('Could not resolve target page', 1742900103, $routeNotFoundException);
+        }
+
+        if (!$route instanceof PageArguments || $route->areDirty()) {
+            throw new InvalidArgumentException('Could not resolve target page arguments', 1742900104);
+        }
+
+        $languageId = $siteMatch->getLanguage()?->getLanguageId();
+        if ($languageId === null) {
+            throw new InvalidArgumentException('Could not resolve target language', 1742900106);
+        }
+
+        $backendUrl = $this->uriBuilder
+            ->buildUriFromRoute(
+                'web_edit',
+                [
+                    'id' => $route->getPageId(),
+                    'languages' => [$languageId],
+                    'params' => $route->getArguments(),
+                ],
+                referenceType: UriBuilder::ABSOLUTE_URL,
+            )
+            ->withScheme($uri->getScheme())
+            ->withHost($uri->getHost())
+            ->withPort($uri->getPort());
+
+        return (string)$backendUrl;
+    }
+}

--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -125,7 +125,7 @@ final readonly class EditModeService
                 'allowNewContent' => $this->languageModeService->getAllowNewContent($pageInformation, $siteLanguage, $request),
                 'token' => $this->formProtectionFactory->createForType('backend')->generateToken('visual_editor', 'save'),
                 'routeArguments' => (object)$this->flattenBracketKeys(['params' => $routing->getRouteArguments()]),
-                'allowedReferrer' => $this->getAllowedReferrer(),
+                'allowedOrigins' => $this->getAllowedOrigins(),
             ];
             $this->assetCollector->addInlineJavaScript(
                 'veLangInfo',
@@ -228,19 +228,19 @@ window.veInfo = ' . json_encode($veInfo, JSON_THROW_ON_ERROR) . ';',
      * returns the origins of all configured sites and languages
      * @return list<string>
      */
-    private function getAllowedReferrer(): array
+    public function getAllowedOrigins(): array
     {
-        $allowedReferrers = [];
+        $allowed = [];
         $sites = $this->siteFinder->getAllSites();
         foreach ($sites as $site) {
             $origin = $site->getBase()->withQuery('')->withPath('')->withUserInfo('')->withFragment('');
-            $allowedReferrers[(string)$origin] = true;
+            $allowed[(string)$origin] = true;
             foreach ($site->getLanguages() as $language) {
                 $origin = $language->getBase()->withQuery('')->withPath('')->withUserInfo('')->withFragment('');
-                $allowedReferrers[(string)$origin] = true;
+                $allowed[(string)$origin] = true;
             }
         }
 
-        return array_keys($allowedReferrers);
+        return array_keys($allowed);
     }
 }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,12 @@
+<?php
+
+use TYPO3\CMS\VisualEditor\Backend\Controller\CrossOriginNavigationController;
+
+return [
+    'visual_editor_resolve_cross_origin_backend_url' => [
+        'path' => '/visual-editor/resolve-cross-origin-backend-url',
+        'target' => CrossOriginNavigationController::class . '::resolveBackendUrlAction',
+        'methods' => ['POST'],
+        'inheritAccessFromModule' => 'web_edit',
+    ],
+];

--- a/Resources/Public/JavaScript/Frontend/index.js
+++ b/Resources/Public/JavaScript/Frontend/index.js
@@ -13,6 +13,7 @@ import {sendMessage} from '@typo3/visual-editor/Shared/iframe-messaging';
 import {highlight, reset} from '@typo3/visual-editor/Frontend/spotlight-overlay';
 import {spotlightActive} from '@typo3/visual-editor/Shared/local-stores';
 import {initSaveScrollPosition} from '@typo3/visual-editor/Frontend/init-save-scroll-position';
+import {initializeCrossOriginNavigations} from '@typo3/visual-editor/Frontend/initializeCrossOriginNavigations';
 
 if (window.location.hash === '#ve-close') {
   sendMessage('closeModal');
@@ -23,7 +24,7 @@ if (window.location.hash === '#ve-close') {
 const element = document.createElement('ve-save-button');
 document.body.appendChild(element);
 
-(function spotlight() {
+(function () {
   const setSpotlight = () => {
     if (spotlightActive.get()) {
       highlight('ve-editable-text, ve-editable-rich-text, .ck-editor__top');
@@ -41,3 +42,4 @@ if (window.veInfo) {
 }
 
 initSaveScrollPosition();
+initializeCrossOriginNavigations();

--- a/Resources/Public/JavaScript/Frontend/initializeCrossOriginNavigations.js
+++ b/Resources/Public/JavaScript/Frontend/initializeCrossOriginNavigations.js
@@ -1,0 +1,46 @@
+async function resolveCrossOriginBackendUrl(url) {
+  const response = await fetch(TYPO3.settings.ajaxUrls.visual_editor_resolve_cross_origin_backend_url, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({url}),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Could not resolve cross-origin backend URL: ${response.status}`);
+  }
+
+  const data = await response.json();
+  if (!data.url) {
+    throw new Error('Missing backend URL in resolver response');
+  }
+
+  return data.url;
+}
+
+export function initializeCrossOriginNavigations() {
+
+  navigation.addEventListener("navigate", (event) => {
+    const newUrl = new URL(event.destination.url);
+    if (newUrl.origin !== window.location.origin) {
+      event.preventDefault();
+
+      if (window.veInfo.allowedOrigins.includes(newUrl.origin)) {
+        resolveCrossOriginBackendUrl(event.destination.url)
+          .then((backendUrl) => {
+            window.top.location = backendUrl;
+          })
+          .catch((error) => {
+            console.error(error);
+            window.open(event.destination.url, '_blank').focus();
+          });
+        return;
+      }
+
+      // open in new Tab and force switch to
+      window.open(event.destination.url, '_blank').focus();
+    }
+  });
+}

--- a/Resources/Public/JavaScript/Shared/iframe-messaging.js
+++ b/Resources/Public/JavaScript/Shared/iframe-messaging.js
@@ -31,7 +31,7 @@ function getPeerOrigin() {
 
   if (document.referrer) {
     const origin = new URL(document.referrer).origin;
-    if (window.veInfo.allowedReferrer.includes(origin)) {
+    if (window.veInfo.allowedOrigins.includes(origin)) {
       return origin;
     }
   }


### PR DESCRIPTION
Avoid cross-origin problems when the visual editor navigates between configured site origins.

Resolve target URLs to the matching `web_edit` backend URL and redirect to the correct backend origin when needed.

Expose configured site origins to the frontend so iframe messaging and navigation handling accept valid TYPO3 origins. Open external origins in a new tab instead.

fixes: #12
related: #19 #20 #22