### PR TITLE
[FEATURE] add TCA validation support for editable text fields

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -13,6 +13,16 @@ on:
     - cron: "0 2 * * 1-5"
 
 jobs:
+  test-js:
+    name: JavaScript tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - run: node --test $(find Resources/Public/JavaScript -name "*.test.js" | sort)
+
   lint-php:
     name: "php: ${{ matrix.php }} TYPO3: ${{ matrix.typo3 }}"
     runs-on: ubuntu-latest

--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -580,6 +580,7 @@ final class PageEditController
             ->setAttributes(['disabled' => 'true'])
             ->setLabel($this->getLanguageService()->sL('LLL:EXT:visual_editor/Resources/Private/Language/locallang.xlf:save'))
             ->setIcon($this->iconFactory->getIcon('actions-save', IconSize::SMALL))
+            ->setTitle('')
             ->setShowLabelText(true);
     }
 

--- a/Classes/ViewHelpers/Render/TextViewHelper.php
+++ b/Classes/ViewHelpers/Render/TextViewHelper.php
@@ -33,6 +33,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use function get_debug_type;
 use function htmlspecialchars;
 use function is_array;
+use function is_int;
 use function is_string;
 use function json_encode;
 use function nl2br;
@@ -165,7 +166,7 @@ final class TextViewHelper extends AbstractViewHelper
         InputFieldType|TextFieldType $field,
         string $label,
         bool $editMode,
-        bool $allowNewlines = false
+        bool $allowNewlines = false,
     ): Input {
         $html = htmlspecialchars($value);
         if ($allowNewlines) {
@@ -191,12 +192,54 @@ final class TextViewHelper extends AbstractViewHelper
         $tag->addAttribute('title', $title);
         $tag->addAttribute('allowNewlines', $allowNewlines);
         $tag->addAttribute('value', str_replace('<br>', "\n", $value));
+        $tag->addAttribute('validation', $this->getInputValidationConfiguration($field, $allowNewlines));
 
         $tag->setContent($html);
 
         $tag->forceClosingTag(true);
 
         return new Input($label, $tag->render(), !$value, $value ?: '');
+    }
+
+    private function getInputValidationConfiguration(InputFieldType|TextFieldType $field, bool $allowNewlines): string
+    {
+        $config = $field->getConfiguration();
+        $validation = [
+            'required' => $field->isRequired(),
+            'allowNewlines' => $allowNewlines,
+        ];
+
+        $min = $config['min'] ?? null;
+        if (is_int($min) || (is_string($min) && $min !== '')) {
+            $min = (int)$min;
+            if ($min > 0) {
+                $validation['min'] = $min;
+            }
+        }
+
+        $max = $config['max'] ?? null;
+        if (is_int($max) || (is_string($max) && $max !== '')) {
+            $max = (int)$max;
+            if ($max > 0) {
+                $validation['max'] = $max;
+            }
+        }
+
+        $evalList = array_flip(GeneralUtility::trimExplode(',', (string)($config['eval'] ?? ''), true));
+
+        $evals = [];
+        $evalOrder = ['trim', 'upper', 'lower', 'alpha', 'num', 'alphanum', 'alphanum_x', 'nospace'];
+        foreach ($evalOrder as $rule) {
+            if (array_key_exists($rule, $evalList)) {
+                $evals[] = $rule;
+            }
+        }
+
+        if ($evals !== []) {
+            $validation['eval'] = $evals;
+        }
+
+        return json_encode($validation, JSON_THROW_ON_ERROR);
     }
 
     private function renderRichText(string $value, RecordInterface $record, TextFieldType $field, string $label, bool $editMode): RichText

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -23,8 +23,41 @@
       <trans-unit id="save.changes">
         <target>%d Änderungen speichern</target>
       </trans-unit>
+      <trans-unit id="save.fixInvalidField">
+        <target>1 Fehler beheben</target>
+      </trans-unit>
+      <trans-unit id="save.fixInvalidFields">
+        <target>%d Fehler beheben</target>
+      </trans-unit>
       <trans-unit id="saving">
         <target>Wird gespeichert ...</target>
+      </trans-unit>
+      <trans-unit id="validation.required">
+        <target>Dieses Feld ist erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="validation.min">
+        <target>Bitte mindestens %d Zeichen eingeben.</target>
+      </trans-unit>
+      <trans-unit id="validation.max">
+        <target>Bitte nicht mehr als %d Zeichen eingeben.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.noNewlines">
+        <target>Zeilenumbrüche sind nicht erlaubt.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.nospace">
+        <target>Leerzeichen sind nicht erlaubt.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.alpha">
+        <target>Es sind nur Buchstaben erlaubt.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.num">
+        <target>Es sind nur Zahlen erlaubt.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.alphanum">
+        <target>Es sind nur Buchstaben und Zahlen erlaubt.</target>
+      </trans-unit>
+      <trans-unit id="inputDenial.alphanum_x">
+        <target>Es sind nur Buchstaben, Zahlen, _ und - erlaubt.</target>
       </trans-unit>
 
       <trans-unit id="frontend.confirmCopy">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -23,8 +23,41 @@
       <trans-unit id="save.changes">
         <source>Save %d changes</source>
       </trans-unit>
+      <trans-unit id="save.fixInvalidField">
+        <source>Fix an error</source>
+      </trans-unit>
+      <trans-unit id="save.fixInvalidFields">
+        <source>Fix %d errors</source>
+      </trans-unit>
       <trans-unit id="saving">
         <source>Saving ...</source>
+      </trans-unit>
+      <trans-unit id="validation.required">
+        <source>This field is required.</source>
+      </trans-unit>
+      <trans-unit id="validation.min">
+        <source>Please enter at least %d characters.</source>
+      </trans-unit>
+      <trans-unit id="validation.max">
+        <source>Please enter no more than %d characters.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.noNewlines">
+        <source>Line breaks are not allowed.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.nospace">
+        <source>Spaces are not allowed.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.alpha">
+        <source>Only letters are allowed.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.num">
+        <source>Only numbers are allowed.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.alphanum">
+        <source>Only letters and numbers are allowed.</source>
+      </trans-unit>
+      <trans-unit id="inputDenial.alphanum_x">
+        <source>Only letters, numbers, _ and - are allowed.</source>
       </trans-unit>
 
       <trans-unit id="frontend.confirmCopy">

--- a/Resources/Public/JavaScript/Backend/components/ve-auto-save-toggle.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-auto-save-toggle.js
@@ -33,24 +33,25 @@ export class VeAutoSaveToggle extends LitElement {
   constructor() {
     super();
     this.count = 0;
+    this.invalidCount = 0;
     this.label = this.innerText;
-    this.disposeChangeListener = null;
+    this.disposeUpdateEditorStateListener = null;
     this.onClick = this.#onClick.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
 
-    if (!this.disposeChangeListener) {
-      this.disposeChangeListener = onMessageDebounced('change', this.#onChangeMessage.bind(this), 300);
+    if (!this.disposeUpdateEditorStateListener) {
+      this.disposeUpdateEditorStateListener = onMessageDebounced('updateEditorState', this.#onEditorStateMessage.bind(this), 300);
     }
 
     this.addEventListener('click', this.onClick);
   }
 
   disconnectedCallback() {
-    this.disposeChangeListener?.();
-    this.disposeChangeListener = null;
+    this.disposeUpdateEditorStateListener?.();
+    this.disposeUpdateEditorStateListener = null;
     this.removeEventListener('click', this.onClick);
 
     super.disconnectedCallback();
@@ -63,9 +64,10 @@ export class VeAutoSaveToggle extends LitElement {
       ${(this.label)}`;
   }
 
-  #onChangeMessage(count) {
+  #onEditorStateMessage({count, invalidCount}) {
     this.count = count;
-    if (this.active && this.count > 0) {
+    this.invalidCount = invalidCount;
+    if (this.active && this.count > 0 && this.invalidCount === 0) {
       sendMessage('doSave');
     }
   }
@@ -76,7 +78,7 @@ export class VeAutoSaveToggle extends LitElement {
 
     autoSaveActive.set(this.active);
 
-    if (this.active && this.count > 0) {
+    if (this.active && this.count > 0 && this.invalidCount === 0) {
       sendMessage('doSave');
     }
   }

--- a/Resources/Public/JavaScript/Backend/components/ve-backend-save-button.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-backend-save-button.js
@@ -2,38 +2,46 @@ import {css, html, LitElement} from 'lit';
 import {lll} from "@typo3/core/lit-helper.js";
 import {onMessage, sendMessage} from '@typo3/visual-editor/Shared/iframe-messaging';
 
+let lastInfo = null;
+
 /**
  * @extends {HTMLElement}
  */
 export class VeBackendSaveButton extends LitElement {
   static properties = {
-    count: {type: Number, reflect: true},
-    disabled: {type: Boolean, reflect: true},
+    count: {type: Number},
+    invalidCount: {type: Number},
     saving: {type: Boolean},
   };
 
-  willUpdate(changedProperties) {
-    this.disabled = this.saving === true || this.count === 0;
+  willUpdate() {
+    this.setAttribute('aria-disabled', this.isVisuallyDisabled ? 'true' : 'false');
+    this.toggleAttribute('disabled', this.isInteractionDisabled);
 
-    this.classList.toggle('btn-default', this.disabled);
-    this.classList.toggle('btn-warning', !this.disabled);
+    this.classList.toggle('btn-default', this.isInteractionDisabled && !this.hasInvalidFields);
+    this.classList.toggle('btn-warning', !this.isVisuallyDisabled);
+    this.classList.toggle('btn-danger', this.hasInvalidFields);
   }
 
   constructor() {
     super();
     this.count = 0;
+    this.invalidCount = 0;
     this.saving = false;
-    this.disabled = true;
-    this.disposeUpdateChangesCountListener = null;
+    this.onClick = this.onClick.bind(this);
+    this.disposeUpdateEditorStateListener = null;
     this.disposeOnSaveListener = null;
     this.disposeSaveEndedListener = null;
+    if (lastInfo) {
+      this.onUpdateEditorState(lastInfo);
+    }
   }
 
   connectedCallback() {
     super.connectedCallback();
 
-    if (!this.disposeUpdateChangesCountListener) {
-      this.disposeUpdateChangesCountListener = onMessage('updateChangesCount', this.onUpdateChangesCount.bind(this));
+    if (!this.disposeUpdateEditorStateListener) {
+      this.disposeUpdateEditorStateListener = onMessage('updateEditorState', this.onUpdateEditorState.bind(this));
     }
     if (!this.disposeOnSaveListener) {
       this.disposeOnSaveListener = onMessage('onSave', this.onSaveMessage.bind(this));
@@ -46,8 +54,8 @@ export class VeBackendSaveButton extends LitElement {
   }
 
   disconnectedCallback() {
-    this.disposeUpdateChangesCountListener?.();
-    this.disposeUpdateChangesCountListener = null;
+    this.disposeUpdateEditorStateListener?.();
+    this.disposeUpdateEditorStateListener = null;
     this.disposeOnSaveListener?.();
     this.disposeOnSaveListener = null;
     this.disposeSaveEndedListener?.();
@@ -62,17 +70,23 @@ export class VeBackendSaveButton extends LitElement {
     if (this.count > 0) {
       label = this.count === 1 ? lll('save.change') : lll('save.changes', this.count);
     }
+    if (this.invalidCount) {
+      label = this.invalidCount === 1 ? lll('save.fixInvalidField') : lll('save.fixInvalidFields', this.invalidCount);
+    }
     if (this.saving) {
       label = lll('saving');
     }
+    const icon = this.hasInvalidFields ? 'actions-exclamation-circle-alt' : 'actions-save';
     return html`
-      <typo3-backend-icon identifier="actions-save" size="small"></typo3-backend-icon>
+      <typo3-backend-icon identifier="${icon}" size="small"></typo3-backend-icon>
       ${label}
     `;
   }
 
-  onUpdateChangesCount(count) {
-    this.count = count;
+  onUpdateEditorState(info) {
+    lastInfo = info;
+    this.count = info.count;
+    this.invalidCount = info.invalidCount;
   }
 
   onSaveMessage() {
@@ -83,16 +97,33 @@ export class VeBackendSaveButton extends LitElement {
     this.saving = false;
 
     if (updatePageTree) {
-      console.log('Updating page tree after save', {updatePageTree});
       top.document.dispatchEvent(new CustomEvent('typo3:pagetree:refresh'));
     }
   }
 
   onClick(e) {
     e.preventDefault();
+    if (this.isInteractionDisabled) {
+      return;
+    }
     sendMessage('doSave');
   }
 
+  get hasChanges() {
+    return this.count > 0;
+  }
+
+  get hasInvalidFields() {
+    return this.invalidCount > 0;
+  }
+
+  get isInteractionDisabled() {
+    return this.saving === true || (!this.hasChanges && !this.hasInvalidFields);
+  }
+
+  get isVisuallyDisabled() {
+    return this.isInteractionDisabled || this.hasInvalidFields;
+  }
 
   static styles = css`
     :host {

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
@@ -151,9 +151,13 @@ export class VeEditableRichText extends LitElement {
     return new Uint8Array(await crypto.subtle.digest('SHA-1', new TextEncoder().encode(input))).toHex();
   }
 
-  #onDataHandlerChange() {
+  #onDataHandlerChange(event) {
+    if (!this.#isRelevantDataHandlerEvent(event.detail)) {
+      return;
+    }
+
     this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
-    const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
+    const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? undefined;
     if (storedValue?.trim() !== this.editor?.getData({ skipListItemIds: true })?.trim()) {
       this.value = storedValue ?? this.value;
       this.editor?.setData(this.value);
@@ -166,6 +170,16 @@ export class VeEditableRichText extends LitElement {
 
   #onDragInProgressChange() {
     this.style.pointerEvents = dragInProgressStore.value ? 'none' : '';
+  }
+
+  #isRelevantDataHandlerEvent(detail) {
+    if (!detail || detail.scope === 'global') {
+      return true;
+    }
+
+    return detail.table === this.table
+      && detail.uid === this.uid
+      && (detail.field === undefined || detail.field === this.field);
   }
 }
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -1,39 +1,58 @@
 import {css, html, LitElement} from 'lit';
+import {lll} from '@typo3/core/lit-helper.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {dataHandlerStore} from '@typo3/visual-editor/Frontend/stores/data-handler-store';
 import {showEmptyActive} from '@typo3/visual-editor/Shared/local-stores';
+import '@typo3/visual-editor/Frontend/components/ve-icon';
+import '@typo3/visual-editor/Frontend/components/ve-validation-overlay';
+import {getEditValue, insertTextAtSelection} from '@typo3/visual-editor/Frontend/components/ve-editable-text/editing';
+import {getValidationIssues, normalizeValue} from '@typo3/visual-editor/Frontend/components/ve-editable-text/validation';
 
 /**
  * @extends {HTMLElement}
  */
 export class VeEditableText extends LitElement {
   static properties = {
-    changed: {type: Boolean, reflect: true,},
-    value: {type: String, reflect: true,},
+    changed: {type: Boolean, reflect: true},
+    value: {type: String, reflect: true},
 
-    name: {type: String,},
-    table: {type: String,},
-    uid: {type: Number,},
-    field: {type: String,},
-    valueInitial: {type: String,},
-    placeholder: {type: String,},
-    allowNewlines: {type: Boolean,},
-    showEmpty: {type: Boolean,},
+    name: {type: String},
+    table: {type: String},
+    uid: {type: Number},
+    field: {type: String},
+    valueInitial: {type: String},
+    placeholder: {type: String},
+    allowNewlines: {type: Boolean},
+    validation: {type: Object},
+    invalid: {type: Boolean, reflect: true},
+    validationErrors: {type: Array},
+    showEmpty: {type: Boolean},
+    focused: {type: Boolean},
+    hovered: {type: Boolean},
   };
 
   constructor() {
     super();
 
-    this.value = this.getAttribute('value');
+    this.value = this.getAttribute('value') ?? '';
     this.valueInitial = this.value;
-    this.innerText = '';
+    this.validation = this.getAttribute('validation') || {};
+    this.invalid = false;
+    this.validationErrors = [];
     this.showEmpty = showEmptyActive.get();
+    this.focused = false;
+    this.hovered = false;
+    this.shakeTimeout = null;
+    this.deniedInputPulseTimeout = null;
+    this.skipNextValueNormalization = false;
     this.onClick = this.#onClick.bind(this);
     this.onMousedown = this.#onMousedown.bind(this);
     this.onPointerdown = this.#onPointerdown.bind(this);
     this.onDragstart = this.#onDragstart.bind(this);
     this.onMouseover = this.#onMouseover.bind(this);
     this.onMouseout = this.#onMouseout.bind(this);
+    this.onMouseenter = this.#onMouseenter.bind(this);
+    this.onMouseleave = this.#onMouseleave.bind(this);
     this.onContextmenu = this.#onContextmenu.bind(this);
     this.onShowEmptyChange = this.#onShowEmptyChange.bind(this);
     this.onDataHandlerChange = this.#onDataHandlerChange.bind(this);
@@ -48,6 +67,8 @@ export class VeEditableText extends LitElement {
     this.addEventListener('dragstart', this.onDragstart);
     this.addEventListener('mouseover', this.onMouseover);
     this.addEventListener('mouseout', this.onMouseout);
+    this.addEventListener('mouseenter', this.onMouseenter);
+    this.addEventListener('mouseleave', this.onMouseleave);
     this.addEventListener('contextmenu', this.onContextmenu);
     showEmptyActive.addEventListener('change', this.onShowEmptyChange);
     dataHandlerStore.addEventListener('change', this.onDataHandlerChange);
@@ -60,9 +81,20 @@ export class VeEditableText extends LitElement {
     this.removeEventListener('dragstart', this.onDragstart);
     this.removeEventListener('mouseover', this.onMouseover);
     this.removeEventListener('mouseout', this.onMouseout);
+    this.removeEventListener('mouseenter', this.onMouseenter);
+    this.removeEventListener('mouseleave', this.onMouseleave);
     this.removeEventListener('contextmenu', this.onContextmenu);
     showEmptyActive.removeEventListener('change', this.onShowEmptyChange);
     dataHandlerStore.removeEventListener('change', this.onDataHandlerChange);
+    if (this.shakeTimeout) {
+      clearTimeout(this.shakeTimeout);
+      this.shakeTimeout = null;
+    }
+    if (this.deniedInputPulseTimeout) {
+      clearTimeout(this.deniedInputPulseTimeout);
+      this.deniedInputPulseTimeout = null;
+    }
+    this.shadowRoot?.querySelector('ve-validation-overlay')?.clear();
 
     super.disconnectedCallback();
   }
@@ -71,18 +103,25 @@ export class VeEditableText extends LitElement {
    * @param changedProperties {Map<PropertyKey, unknown>}
    */
   firstUpdated(changedProperties) {
-    this.placeholder = '👀' + (this.placeholder || this.title);
-    this.shadowRoot.querySelector('.slot').innerText = this.valueInitial || '';
+    this.placeholder = '👀' + this.title;
+    this.skipNextValueNormalization = true;
+    this.#setSlotText(this.valueInitial);
     dataHandlerStore.setInitialData(this.table, this.uid, this.field, this.valueInitial);
+    this.#applyValidationState(this.valueInitial);
   }
 
   updated(changedProperties) {
     this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
-    if (changedProperties.has('value')) {
-      dataHandlerStore.setData(this.table, this.uid, this.field, this.value);
+    if (changedProperties.has('value') || changedProperties.has('validation')) {
+      if (this.skipNextValueNormalization) {
+        this.skipNextValueNormalization = false;
+        this.#applyValidationState(this.value);
+      } else {
+        this.#validateAndStore(this.value);
+      }
     }
 
-    const hideEmpty = !this.showEmpty && this.value === '' && !this.matches(':focus-within') && !this.changed;
+    const hideEmpty = !this.showEmpty && this.value === '' && !this.focused && !this.changed && !this.invalid;
     if (hideEmpty) {
       this.style.display = 'none';
       if (this.parentElement.innerText.trim() === '') {
@@ -96,44 +135,91 @@ export class VeEditableText extends LitElement {
 
   onReset = () => {
     this.value = this.valueInitial;
-    this.shadowRoot.querySelector('.slot').innerText = this.valueInitial;
+    this.#setSlotText(this.valueInitial);
+    this.skipNextValueNormalization = true;
+    this.#applyValidationState(this.valueInitial);
+    dataHandlerStore.setData(this.table, this.uid, this.field, this.valueInitial);
   };
 
-  render() {
-    let buttonCount = 0;
-    let buttons = html``;
-    if (this.changed) {
-      buttonCount = 1;
-      buttons = html`
-        <div class="buttons">
-          <ve-reset-button @click="${this.onReset}"></ve-reset-button>
-        </div>`;
+  /**
+   * @api used by initialize-save-handling.js focusFirstInvalidField function
+   */
+  focusEditable() {
+    this.style.display = '';
+    if (this.parentElement) {
+      this.parentElement.style.display = '';
     }
+    this.scrollIntoView({
+      block: 'center',
+      inline: 'nearest',
+      behavior: 'auto',
+    });
+
+    const slot = this.shadowRoot?.querySelector('.slot');
+    slot?.focus({preventScroll: true});
+  }
+
+  render() {
+    const showValidationErrors = this.hovered || this.focused;
+    const showInvalidIcon = this.invalid;
+    const buttonControls = [];
+
+    if (showInvalidIcon) {
+      buttonControls.push(html`
+        <span class="status-icon" title="${this.validationErrors[0] || ''}" aria-hidden="true">
+          <ve-icon name="actions-exclamation-circle-alt" width="100%"></ve-icon>
+        </span>
+      `);
+    }
+
+    if (this.changed) {
+      buttonControls.push(html`
+        <ve-reset-button @click="${this.onReset}"></ve-reset-button>
+      `);
+    }
+
+    const buttonCount = buttonControls.length;
+    const buttons = buttonCount > 0 ? html`
+      <div class="buttons">
+        ${buttonControls}
+      </div>` : html``;
     const shouldBeInline = this.shouldBeInline();
 
     this.classList.toggle('block', !shouldBeInline);
+
+    const slot = this.shadowRoot?.querySelector('.slot');
+    const showPlaceholder = !this.focused && !(slot?.innerText || this.value).length;
     return html`
       <span
-        class=${classMap({slot: true, synced: this.isSynced, changed: this.changed, block: !shouldBeInline})}
+        class=${classMap({
+          slot: true,
+          changed: this.changed,
+          invalid: this.invalid,
+          block: !shouldBeInline,
+        })}
         style="--button-count: ${buttonCount};"
-        contenteditable="${this.isSynced ? 'false' : 'plaintext-only'}"
+        contenteditable="plaintext-only"
         role="textbox"
+        aria-invalid="${this.invalid ? 'true' : 'false'}"
         spellcheck="true"
-        data-placeholder="${this.value.length ? '' : (this.placeholder || '\u200B'/* placeholder keeps firefox from breaking out*/)}"
-        @input="${(event) => {
-          this.value = event.currentTarget.innerText.trim();
-          if (this.value.length === 0) {
-            this.shadowRoot.querySelector('.slot').innerText = '';
-          }
+        data-placeholder="${showPlaceholder ? (this.placeholder || '\u200B'/* placeholder keeps firefox from breaking out*/) : ''}"
+        @focus="${() => {
+          this.#handleFocus();
         }}"
-        @blur="${() => this.shadowRoot.querySelector('.slot').innerText = this.value}"
-        @keypress="${(event) => {
-          if (event.which === 13 && !this.allowNewlines) {
-            event.preventDefault();
-          }
+        @beforeinput="${(event) => {
+          this.#handleBeforeInput(event.currentTarget, event);
+        }}"
+        @input="${(event) => {
+          this.#handleInput();
+        }}"
+        @blur="${(event) => {
+          this.#handleBlur();
         }}"
       ></span>
       ${buttons}
+      <ve-validation-overlay
+        .validationErrors=${showValidationErrors ? this.validationErrors : []}
+      ></ve-validation-overlay>
     `;
   }
 
@@ -222,6 +308,14 @@ export class VeEditableText extends LitElement {
     }
   }
 
+  #onMouseenter() {
+    this.hovered = true;
+  }
+
+  #onMouseleave() {
+    this.hovered = false;
+  }
+
   #onContextmenu() {
     const aTag = this.#getClosestAnchor();
     if (!aTag) {
@@ -236,17 +330,192 @@ export class VeEditableText extends LitElement {
     this.showEmpty = showEmptyActive.get();
   }
 
-  #onDataHandlerChange() {
+  #onDataHandlerChange(event) {
+    if (!this.#isRelevantDataHandlerEvent(event.detail)) {
+      return;
+    }
+
     this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
     this.valueInitial = dataHandlerStore.initialData[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
     const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? this.valueInitial;
     const slot = this.shadowRoot?.querySelector('.slot');
-    if (storedValue?.trim() !== slot?.innerText?.trim()) {
+    const isFocused = this.matches(':focus-within');
+    if (!isFocused && storedValue?.trim() !== slot?.innerText?.trim()) {
+      this.skipNextValueNormalization = true;
       this.value = storedValue ?? this.value;
-      if (slot) {
-        slot.innerText = this.value;
+      this.#setSlotText(this.value);
+    }
+  }
+
+  /**
+   * @param {string} value
+   */
+  #setSlotText(value) {
+    const element = this.shadowRoot?.querySelector('.slot');
+    if (element) {
+      element.innerText = value;
+    }
+  }
+
+  #getSlotText() {
+    return this.shadowRoot?.querySelector('.slot')?.innerText.replace(/\n$/, '') ?? '';
+  }
+
+  /**
+   * @param {HTMLElement} element
+   * @param {InputEvent} event
+   */
+  #handleBeforeInput(element, event) {
+    const edit = getEditValue(element, event);
+    if (edit === null) {
+      return;
+    }
+
+    if (edit.type === 'delete') {
+      return;
+    }
+
+    if (edit.type === 'insertBreak') {
+      if (!this.allowNewlines) {
+        event.preventDefault();
+        this.#showDeniedInputReason(lll('inputDenial.noNewlines'), element);
+      }
+      return;
+    }
+
+    const {text, reasons} = normalizeValue(edit.insertedText, this.validation);
+    let insertedText = text;
+
+    for (const reason of reasons) {
+      this.#showDeniedInputReason(lll(reason.key, ...(reason.args || [])), element);
+    }
+
+    const nextValue = edit.currentValue.slice(0, edit.start) + insertedText + edit.currentValue.slice(edit.end);
+
+    if (!this.allowNewlines) {
+      if (insertedText.match(/\n/)) {
+        insertedText = insertedText.replaceAll(/\n/g, '');
+        this.#showDeniedInputReason(lll('inputDenial.noNewlines'), element);
       }
     }
+
+    const max = Number(this.validation?.max || 0);
+    if (max > 0 && nextValue.length > max) {
+      insertedText = insertedText.slice(0, max - edit.currentValue.length + (edit.end - edit.start));
+      this.#showDeniedInputReason(lll('validation.max', max), element);
+    }
+
+    if (insertedText !== edit.insertedText) {
+      event.preventDefault();
+      insertTextAtSelection(element, insertedText);
+      this.#validateAndStore(this.#getSlotText());
+    }
+  }
+
+  #handleInput() {
+    this.#validateAndStore(this.#getSlotText());
+  }
+
+  #handleFocus() {
+    this.focused = true;
+  }
+
+  #handleBlur() {
+    this.focused = false;
+    this.#setSlotText(this.#validateAndStore(this.#getSlotText()));
+  }
+
+  /**
+   * @param {string} reason
+   * @param {HTMLElement} element
+   */
+  #showDeniedInputReason(reason, element) {
+    if (!reason) {
+      return;
+    }
+
+    this.#shakeInvalidInput(element);
+    this.#restartDeniedInputPulse(element);
+    this.shadowRoot?.querySelector('ve-validation-overlay')?.show(reason);
+  }
+
+  /**
+   * @param {HTMLElement} element
+   */
+  #shakeInvalidInput(element) {
+    element.classList.remove('shake-invalid');
+    void element.offsetWidth;
+    element.classList.add('shake-invalid');
+    if (this.shakeTimeout) {
+      clearTimeout(this.shakeTimeout);
+    }
+    this.shakeTimeout = setTimeout(() => {
+      element.classList.remove('shake-invalid');
+      this.shakeTimeout = null;
+    }, 250);
+  }
+
+  /**
+   * @param {HTMLElement} element
+   */
+  #restartDeniedInputPulse(element) {
+    element.classList.remove('deniedInputPulse');
+    void element.offsetWidth;
+    element.classList.add('deniedInputPulse');
+    if (this.deniedInputPulseTimeout) {
+      clearTimeout(this.deniedInputPulseTimeout);
+    }
+    this.deniedInputPulseTimeout = setTimeout(() => {
+      element.classList.remove('deniedInputPulse');
+      this.deniedInputPulseTimeout = null;
+    }, 2000);
+  }
+
+  /**
+   * @param {string} value
+   * @returns {string}
+   */
+  #validateAndStore(value) {
+    this.value = value;
+    this.#applyValidationState(value);
+
+    let normalizedValue = normalizeValue(value, this.validation).text;
+
+    const min = Number(this.validation?.min || 0);
+    const isRequired = Boolean(this.validation?.required || false);
+    if (normalizedValue.length < min && !isRequired) {
+      normalizedValue = '';
+    }
+
+    const max = Number(this.validation?.max || 0);
+    if (max > 0 && normalizedValue.length > max) {
+      normalizedValue = normalizedValue.slice(0, max);
+    }
+
+    dataHandlerStore.setData(this.table, this.uid, this.field, normalizedValue);
+    return normalizedValue;
+  }
+
+  /**
+   * @param {string} value
+   */
+  #applyValidationState(value) {
+    const validationErrors = getValidationIssues(value, this.validation)
+      .map(({key, args = []}) => lll(key, ...args));
+    this.invalid = validationErrors.length > 0;
+    this.validationErrors = validationErrors;
+
+    dataHandlerStore.setInvalid(this.table, this.uid, this.field, this.invalid);
+  }
+
+  #isRelevantDataHandlerEvent(detail) {
+    if (!detail || detail.scope === 'global') {
+      return true;
+    }
+
+    return detail.table === this.table
+      && detail.uid === this.uid
+      && detail.field === this.field;
   }
 
   static styles = css`
@@ -279,8 +548,9 @@ export class VeEditableText extends LitElement {
       --padding-right: calc(4px + var(--button-size) * var(--button-count) + 4px * 2 * var(--button-count));
       padding: 4px var(--padding-right) 4px 4px;
       margin: -4px;
+      outline: 0.25rem solid transparent;
 
-      transition: box-shadow 0.2s, backdrop-filter 0.2s, outline 0.2s;
+      transition: backdrop-filter 0.2s;
 
       &:before {
         content: attr(data-placeholder);
@@ -291,25 +561,37 @@ export class VeEditableText extends LitElement {
     .slot:hover, .slot:focus {
       box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.50) inset;
       backdrop-filter: blur(10px) invert(20%);
-      outline: 0.25rem solid #5432fe;
+      outline-color: #5432fe;
     }
 
     .slot.block {
       display: block;
     }
 
-    .slot.synced {
-      /* blur the text: */
-      user-select: none;
-      // TODO use backdrop-filter
-      color: #888;
-      background: #f2f2f2;
-      outline-color: #bfbfbf;
-      cursor: not-allowed;
-    }
-
     .slot.changed {
       backdrop-filter: blur(10px) hue-rotate(120deg) invert(30%);
+    }
+
+    .slot.invalid {
+      outline-color: #a40000;
+      box-shadow: 0 0 4px 0 rgba(164, 0, 0, 0.7) inset;
+    }
+
+    .slot.shake-invalid {
+      animation: shake-invalid 0.2s ease-in-out;
+    }
+
+    .slot.deniedInputPulse {
+      outline-color: #a40000;
+      box-shadow: 0 0 4px 0 rgba(164, 0, 0, 0.7) inset;
+    }
+
+    .slot.deniedInputPulse {
+      animation: denied-input-pulse 4s ease-out;
+    }
+
+    .slot.shake-invalid.deniedInputPulse {
+      animation: shake-invalid 0.2s ease-in-out, denied-input-pulse 4s ease-out;
     }
 
     .buttons {
@@ -337,6 +619,50 @@ export class VeEditableText extends LitElement {
           color: black;
           background-color: #e6e6e6;
         }
+      }
+    }
+
+    .status-icon {
+      color: #a40000;
+      pointer-events: none;
+      cursor: default;
+
+      ve-icon {
+        display: block;
+      }
+    }
+
+    @keyframes shake-invalid {
+      0% {
+        transform: translateX(0);
+      }
+
+      25% {
+        transform: translateX(-3px);
+      }
+
+      50% {
+        transform: translateX(3px);
+      }
+
+      75% {
+        transform: translateX(-2px);
+      }
+
+      100% {
+        transform: translateX(0);
+      }
+    }
+
+    @keyframes denied-input-pulse {
+      0% {
+        outline-color: rgba(164, 0, 0, 1);
+        box-shadow: 0 0 4px 0 rgba(164, 0, 0, 0.7) inset;
+      }
+
+      100% {
+        outline-color: rgba(164, 0, 0, 0);
+        box-shadow: 0 0 4px 0 rgba(164, 0, 0, 0) inset;
       }
     }
   `;

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/editing.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/editing.js
@@ -1,0 +1,97 @@
+/**
+ * @param {HTMLElement} element
+ * @returns {{start: number, end: number}}
+ */
+export function getSelectionOffsets(element) {
+  const currentValue = element.innerText || '';
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return {start: currentValue.length, end: currentValue.length};
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.startContainer) || !element.contains(range.endContainer)) {
+    return {start: currentValue.length, end: currentValue.length};
+  }
+
+  const beforeRange = range.cloneRange();
+  beforeRange.selectNodeContents(element);
+  beforeRange.setEnd(range.startContainer, range.startOffset);
+  const start = beforeRange.toString().length;
+  const end = start + range.toString().length;
+
+  return {start, end};
+}
+
+/**
+ * @param {HTMLElement} element
+ * @param {InputEvent} event
+ * @returns {object|null}
+ */
+export function getEditValue(element, event) {
+  const currentValue = element.innerText || '';
+  const {start, end} = getSelectionOffsets(element);
+
+  switch (event.inputType) {
+    case 'insertText':
+    case 'insertCompositionText':
+    case 'insertReplacementText':
+    case 'insertFromPaste':
+    case 'insertFromDrop':
+    case 'insertFromYank': {
+      const insertedText = event.dataTransfer?.getData('text/plain') ?? event.data ?? '';
+      return {type: 'insert', currentValue, insertedText, start, end};
+    }
+    case 'insertLineBreak':
+    case 'insertParagraph':
+      return {type: 'insertBreak', currentValue, insertedText: '\n', start, end};
+    case 'deleteContent':
+    case 'deleteByCut':
+    case 'deleteByDrag':
+      return {type: 'delete', nextValue: currentValue.slice(0, start) + currentValue.slice(end)};
+    case 'deleteContentBackward':
+      if (start !== end) {
+        return {type: 'delete', nextValue: currentValue.slice(0, start) + currentValue.slice(end)};
+      }
+      if (start === 0) {
+        return {type: 'delete', nextValue: currentValue};
+      }
+      return {type: 'delete', nextValue: currentValue.slice(0, start - 1) + currentValue.slice(end)};
+    case 'deleteContentForward':
+      if (start !== end) {
+        return {type: 'delete', nextValue: currentValue.slice(0, start) + currentValue.slice(end)};
+      }
+      if (start >= currentValue.length) {
+        return {type: 'delete', nextValue: currentValue};
+      }
+      return {type: 'delete', nextValue: currentValue.slice(0, start) + currentValue.slice(start + 1)};
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {HTMLElement} element
+ * @param {string} text
+ */
+export function insertTextAtSelection(element, text) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    element.innerText += text;
+    return;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.startContainer) || !element.contains(range.endContainer)) {
+    element.innerText += text;
+    return;
+  }
+
+  range.deleteContents();
+  const textNode = document.createTextNode(text);
+  range.insertNode(textNode);
+  range.setStart(textNode, text.length);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/editing.test.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/editing.test.js
@@ -1,0 +1,196 @@
+import test, {afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {getEditValue, getSelectionOffsets, insertTextAtSelection} from './editing.js';
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+afterEach(() => {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+});
+
+function setSelection({start, selectedText = '', inside = true}) {
+  const startContainer = {};
+  const endContainer = {};
+  const beforeRange = {
+    selectNodeContents() {},
+    setEnd(container, offset) {
+      assert.equal(container, startContainer);
+      assert.equal(offset, 0);
+    },
+    toString() {
+      return 'x'.repeat(start);
+    },
+  };
+  const range = {
+    startContainer,
+    endContainer,
+    startOffset: 0,
+    endOffset: 0,
+    cloneRange() {
+      return beforeRange;
+    },
+    toString() {
+      return selectedText;
+    },
+    deleteContents() {},
+    insertNode() {},
+    setStart() {},
+    collapse() {},
+  };
+
+  globalThis.window = {
+    getSelection() {
+      return {
+        rangeCount: 1,
+        getRangeAt() {
+          return range;
+        },
+      };
+    },
+  };
+
+  return {
+    contains(node) {
+      return inside && (node === startContainer || node === endContainer);
+    },
+  };
+}
+
+test('getSelectionOffsets falls back to the end when there is no selection', () => {
+  globalThis.window = {
+    getSelection() {
+      return null;
+    },
+  };
+
+  const offsets = getSelectionOffsets({innerText: 'abcd'});
+
+  assert.deepEqual(offsets, {start: 4, end: 4});
+});
+
+test('getSelectionOffsets falls back when the selection is outside the element', () => {
+  const element = {
+    innerText: 'abcd',
+    contains() {
+      return false;
+    },
+  };
+  setSelection({start: 1, selectedText: 'b', inside: false});
+
+  const offsets = getSelectionOffsets(element);
+
+  assert.deepEqual(offsets, {start: 4, end: 4});
+});
+
+test('getEditValue returns insert data for text and paste events', () => {
+  globalThis.window = {
+    getSelection() {
+      return null;
+    },
+  };
+  const element = {innerText: 'abc'};
+
+  assert.deepEqual(getEditValue(element, {
+    inputType: 'insertText',
+    data: 'x',
+  }), {
+    type: 'insert',
+    currentValue: 'abc',
+    insertedText: 'x',
+    start: 3,
+    end: 3,
+  });
+
+  assert.deepEqual(getEditValue(element, {
+    inputType: 'insertFromPaste',
+    data: null,
+    dataTransfer: {
+      getData(type) {
+        assert.equal(type, 'text/plain');
+        return 'pasted';
+      },
+    },
+  }), {
+    type: 'insert',
+    currentValue: 'abc',
+    insertedText: 'pasted',
+    start: 3,
+    end: 3,
+  });
+});
+
+test('getEditValue returns line breaks for paragraph insertion', () => {
+  globalThis.window = {
+    getSelection() {
+      return null;
+    },
+  };
+
+  const value = getEditValue({innerText: 'abc'}, {inputType: 'insertParagraph'});
+
+  assert.deepEqual(value, {
+    type: 'insertBreak',
+    currentValue: 'abc',
+    insertedText: '\n',
+    start: 3,
+    end: 3,
+  });
+});
+
+test('getEditValue handles delete branches', () => {
+  const element = Object.assign({innerText: 'abcd'}, setSelection({start: 1, selectedText: 'bc'}));
+
+  assert.deepEqual(getEditValue(element, {inputType: 'deleteContent'}), {
+    type: 'delete',
+    nextValue: 'ad',
+  });
+
+  Object.assign(element, setSelection({start: 0}));
+  assert.deepEqual(getEditValue(element, {inputType: 'deleteContentBackward'}), {
+    type: 'delete',
+    nextValue: 'abcd',
+  });
+
+  Object.assign(element, setSelection({start: 2}));
+  assert.deepEqual(getEditValue(element, {inputType: 'deleteContentBackward'}), {
+    type: 'delete',
+    nextValue: 'acd',
+  });
+
+  Object.assign(element, setSelection({start: 4}));
+  assert.deepEqual(getEditValue(element, {inputType: 'deleteContentForward'}), {
+    type: 'delete',
+    nextValue: 'abcd',
+  });
+
+  Object.assign(element, setSelection({start: 1}));
+  assert.deepEqual(getEditValue(element, {inputType: 'deleteContentForward'}), {
+    type: 'delete',
+    nextValue: 'acd',
+  });
+});
+
+test('getEditValue returns null for unsupported input types', () => {
+  globalThis.window = {
+    getSelection() {
+      return null;
+    },
+  };
+
+  assert.equal(getEditValue({innerText: 'abc'}, {inputType: 'formatBold'}), null);
+});
+
+test('insertTextAtSelection appends when there is no usable selection', () => {
+  globalThis.window = {
+    getSelection() {
+      return null;
+    },
+  };
+
+  const element = {innerText: 'abc'};
+  insertTextAtSelection(element, 'x');
+
+  assert.equal(element.innerText, 'abcx');
+});

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.js
@@ -1,0 +1,87 @@
+/**
+ * @typedef {{key: string, args?: Array<string|number>}} ValidationMessage
+ */
+
+/**
+ * @param {string} input
+ * @param {Record<string, any>} validation
+ * @returns {{text: string, reasons: ValidationMessage[]}}
+ */
+export function normalizeValue(input, validation) {
+  let text = input;
+  const reasons = [];
+
+  const evalList = Array.isArray(validation?.eval) ? validation.eval : [];
+  for (const evalName of evalList) {
+    switch (evalName) {
+      case 'trim':
+        text = text.trim();
+        break;
+      case 'upper':
+        text = text.toLocaleUpperCase();
+        break;
+      case 'lower':
+        text = text.toLocaleLowerCase();
+        break;
+      case 'nospace':
+        if (text.includes(' ')) {
+          text = text.replaceAll(' ', '');
+          reasons.push({key: 'inputDenial.nospace'});
+        }
+        break;
+      case 'alpha':
+        if (text.match(/[^a-zA-Z]/g)) {
+          text = text.replaceAll(/[^a-zA-Z]/g, '');
+          reasons.push({key: 'inputDenial.alpha'});
+        }
+        break;
+      case 'num':
+        if (text.match(/[^0-9]/g)) {
+          text = text.replaceAll(/[^0-9]/g, '');
+          reasons.push({key: 'inputDenial.num'});
+        }
+        break;
+      case 'alphanum':
+        if (text.match(/[^a-zA-Z0-9]/g)) {
+          text = text.replaceAll(/[^a-zA-Z0-9]/g, '');
+          reasons.push({key: 'inputDenial.alphanum'});
+        }
+        break;
+      case 'alphanum_x':
+        if (text.match(/[^a-zA-Z0-9_-]/g)) {
+          text = text.replaceAll(/[^a-zA-Z0-9_-]/g, '');
+          reasons.push({key: 'inputDenial.alphanum_x'});
+        }
+        break;
+    }
+  }
+
+  return {text, reasons};
+}
+
+/**
+ * @param {string} value
+ * @param {Record<string, any>} validation
+ * @returns {ValidationMessage[]}
+ */
+export function getValidationIssues(value, validation) {
+  const {reasons} = normalizeValue(value, validation);
+  const errors = [...reasons];
+  const isEmpty = value === '';
+
+  if (validation?.required && isEmpty) {
+    errors.push({key: 'validation.required'});
+  }
+
+  const min = Number(validation?.min || 0);
+  if (!isEmpty && min > 0 && value.length < min) {
+    errors.push({key: 'validation.min', args: [min]});
+  }
+
+  const max = Number(validation?.max || 0);
+  if (max > 0 && value.length > max) {
+    errors.push({key: 'validation.max', args: [max]});
+  }
+
+  return errors;
+}

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.test.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {getValidationIssues, normalizeValue} from './validation.js';
+
+test('normalizeValue trims before later validation checks are applied', () => {
+  const result = normalizeValue(' ab ', {eval: ['trim']});
+
+  assert.equal(result.text, 'ab');
+  assert.deepEqual(result.reasons, []);
+});
+
+test('getValidationIssues uses original text for required validation', () => {
+  const issues = getValidationIssues('   ', {eval: ['trim'], required: true});
+
+  assert.deepEqual(issues, []);
+});
+
+test('getValidationIssues uses original text for min validation', () => {
+  const issues = getValidationIssues(' a ', {eval: ['trim'], min: 2});
+
+  assert.deepEqual(issues, []);
+});
+
+test('getValidationIssues allows empty values when min is set without required', () => {
+  const issues = getValidationIssues('', {min: 3, required: false});
+
+  assert.deepEqual(issues, []);
+});
+
+test('getValidationIssues uses original text for max validation', () => {
+  const issues = getValidationIssues(' ab ', {eval: ['trim'], max: 2});
+
+  assert.deepEqual(issues, [{key: 'validation.max', args: [2]}]);
+});
+
+test('getValidationIssues keeps the reported headline text valid with max length only', () => {
+  const issues = getValidationIssues('A fresh foundation for every project', {
+    required: false,
+    allowNewlines: false,
+    max: 255,
+  });
+
+  assert.deepEqual(issues, []);
+});
+
+test('getValidationIssues keeps denied reasons when normalization results in an allowed empty value', () => {
+  const issues = getValidationIssues(' 1 ', {eval: ['trim', 'alpha'], min: 2});
+
+  assert.deepEqual(issues, [{key: 'inputDenial.alpha'}]);
+});
+
+test('getValidationIssues prefers unchanged max validation over normalization denial reasons', () => {
+  const issues = getValidationIssues('Visual Editing for TYPO3', {
+    required: false,
+    allowNewlines: false,
+    min: 3,
+    max: 10,
+    eval: ['upper', 'num', 'alphanum', 'nospace'],
+  });
+
+  assert.deepEqual(issues, [
+    {key: 'inputDenial.num'},
+    {key: 'validation.max', args: [10]},
+  ]);
+});
+
+test('getValidationIssues keeps eval validation for unchanged values when no higher-priority issue exists', () => {
+  const issues = getValidationIssues(' 1 ', {
+    eval: ['trim', 'alpha'],
+  });
+
+  assert.deepEqual(issues, [{key: 'inputDenial.alpha'}]);
+});
+
+test('getValidationIssues uses validatedText emptiness for unchanged required validation', () => {
+  const issues = getValidationIssues('   ', {
+    eval: ['trim', 'alpha'],
+    required: true,
+  });
+
+  assert.deepEqual(issues, []);
+});
+
+test('getValidationIssues returns unchanged min and eval errors together', () => {
+  const issues = getValidationIssues('1', {
+    eval: ['alpha'],
+    min: 2,
+  });
+
+  assert.deepEqual(issues, [
+    {key: 'inputDenial.alpha'},
+    {key: 'validation.min', args: [2]},
+  ]);
+});

--- a/Resources/Public/JavaScript/Frontend/components/ve-icon.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-icon.js
@@ -25,6 +25,7 @@ export class VeIcon extends LitElement {
     'actions-document-add': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g fill="currentColor"><path d="M7 14H2V2h12v5l1 1V1.5a.5.5 0 0 0-.5-.5h-13a.5.5 0 0 0-.5.5v13a.5.5 0 0 0 .5.5H8l-1-1z"/><path d="M3 3h10v2H3zM3 6h8l-1 1H3zM3 10h4l-1 1H3zM3 12h3v1H3zM3 8h6L8 9H3zM15.5 13H13v2.5a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5V13H8.5a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5H11V8.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5V11h2.5a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5z"/></g></svg>',
     'apps-pagetree-drag-move-into': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g><path fill="#AAA" d="M.5 10.5v-5h2.293l1 1H6.5v4z"/><path fill="#666" d="m2.586 6 .707.707.293.293H6v3H1V6h1.586M3 5H0v6h7V6H4L3 5z"/></g><path fill="currentColor" d="M13 11 9 8.5 13 6v2h3v1h-3z"/></svg>',
     'actions-undo': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g fill="currentColor"><path d="M8 2c-1.8 0-3.4.8-4.5 2l-1-1c-.2-.2-.4-.1-.4.1l-.9 3.8c0 .2.1.3.3.3l3.8-.9c.2 0 .3-.3.1-.4l-1-1c.9-1 2.2-1.7 3.7-1.7 2.7 0 4.9 2.2 4.9 4.9S10.8 13 8.1 13c-1.5 0-2.8-.7-3.7-1.7l-.9.7c1.1 1.2 2.7 2 4.5 2 3.3 0 6-2.7 6-6s-2.7-6-6-6z"/></g></svg>',
+    'actions-exclamation-circle-alt': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g fill="currentColor"><path d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm-.448 3h.896a.5.5 0 0 1 .497.55L8.5 9h-1l-.445-4.45A.5.5 0 0 1 7.552 4zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/></g></svg>',
   };
 
   // createRenderRoot() {

--- a/Resources/Public/JavaScript/Frontend/components/ve-validation-message.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-validation-message.js
@@ -1,0 +1,182 @@
+import {css, html, LitElement} from 'lit';
+
+export class VeValidationMessage extends LitElement {
+  static properties = {
+    reason: {type: String},
+    animationKey: {type: Number},
+    shakeKey: {type: Number},
+    animated: {type: Boolean},
+  };
+
+  constructor() {
+    super();
+    this.reason = '';
+    this.animationKey = 0;
+    this.shakeKey = 0;
+    this.animated = false;
+    this.shakeTimeout = null;
+  }
+
+  firstUpdated() {
+    this.#syncAnimationState();
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('animationKey') && this.animated) {
+      this.#restartFadeAnimation();
+      this.#restartShakeAnimation();
+      return;
+    }
+
+    if (changedProperties.has('shakeKey') && changedProperties.get('shakeKey') !== undefined) {
+      this.#restartShakeAnimation();
+    }
+
+    if (changedProperties.has('animated')) {
+      this.#syncAnimationState();
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.shakeTimeout) {
+      clearTimeout(this.shakeTimeout);
+      this.shakeTimeout = null;
+    }
+    super.disconnectedCallback();
+  }
+
+  render() {
+    return html`
+      <div class="validation-bubble bubble ${this.animated ? 'animate' : ''}" aria-live="polite">
+        ${this.reason}
+      </div>
+    `;
+  }
+
+  #syncAnimationState() {
+    if (!this.animated) {
+      const bubble = this.shadowRoot?.querySelector('.bubble');
+      bubble?.classList.remove('animate', 'shake-invalid');
+      if (this.shakeTimeout) {
+        clearTimeout(this.shakeTimeout);
+        this.shakeTimeout = null;
+      }
+      return;
+    }
+
+    this.#restartFadeAnimation();
+  }
+
+  #restartFadeAnimation() {
+    const bubble = this.shadowRoot?.querySelector('.bubble');
+    if (!bubble || !this.animated) {
+      bubble?.classList.remove('animate');
+      return;
+    }
+
+    bubble.classList.remove('animate');
+    void bubble.offsetWidth;
+    bubble.classList.add('animate');
+  }
+
+  #restartShakeAnimation() {
+    const bubble = this.shadowRoot?.querySelector('.bubble');
+    if (!bubble) {
+      return;
+    }
+
+    bubble.classList.remove('shake-invalid');
+    void bubble.offsetWidth;
+    bubble.classList.add('shake-invalid');
+
+    if (this.shakeTimeout) {
+      clearTimeout(this.shakeTimeout);
+    }
+
+    this.shakeTimeout = setTimeout(() => {
+      bubble.classList.remove('shake-invalid');
+      this.shakeTimeout = null;
+    }, 250);
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .validation-bubble {
+      display: block;
+      width: max-content;
+      padding: 0.4rem 0.55rem;
+      border-radius: 0.45rem;
+      border: 1px solid rgba(164, 0, 0, 0.35);
+      background: rgba(255, 248, 248, 0.96);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+      backdrop-filter: blur(10px);
+      color: #a40000;
+      font-size: 14px;
+      line-height: 1.3;
+      text-wrap: pretty;
+      font-family: "Open Sans", serif;
+      font-weight: normal;
+    }
+
+    .bubble {
+      will-change: opacity, transform;
+    }
+
+    .bubble.animate {
+      animation: denied-input-fade 4s ease-out forwards;
+    }
+
+    .bubble.shake-invalid {
+      animation: shake-invalid 0.2s ease-in-out;
+    }
+
+    .bubble.animate.shake-invalid {
+      animation: shake-invalid 0.2s ease-in-out, denied-input-fade 4s ease-out forwards;
+    }
+
+    @keyframes denied-input-fade {
+      0% {
+        opacity: 1;
+      }
+
+      50% {
+        opacity: 1;
+      }
+
+      90% {
+        opacity: 0.5;
+      }
+
+      100% {
+        opacity: 0;
+      }
+    }
+
+    @keyframes shake-invalid {
+      0% {
+        transform: translateX(0);
+      }
+
+      25% {
+        transform: translateX(-3px);
+      }
+
+      50% {
+        transform: translateX(3px);
+      }
+
+      75% {
+        transform: translateX(-2px);
+      }
+
+      100% {
+        transform: translateX(0);
+      }
+    }
+  `;
+}
+
+customElements.define('ve-validation-message', VeValidationMessage);

--- a/Resources/Public/JavaScript/Frontend/components/ve-validation-overlay.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-validation-overlay.js
@@ -1,0 +1,154 @@
+import {css, html, LitElement} from 'lit';
+import '@typo3/visual-editor/Frontend/components/ve-validation-message';
+
+export class VeValidationOverlay extends LitElement {
+  static properties = {
+    messages: {type: Array},
+    validationErrors: {type: Array},
+  };
+
+  constructor() {
+    super();
+    this.messages = [];
+    this.validationErrors = [];
+    this.messageId = 0;
+    this.clearTimeouts = new Map();
+    this.validationErrorShakeKeys = new Map();
+  }
+
+  render() {
+    if (this.messages.length === 0 && this.validationErrors.length === 0) {
+      return html``;
+    }
+
+    const uniqueValidationErrors = [...new Set(this.validationErrors)];
+
+    return html`
+      <div class="messageOverlay">
+        ${uniqueValidationErrors.map((reason) => html`
+          <ve-validation-message
+            .reason=${reason}
+            .animated=${false}
+            .shakeKey=${this.validationErrorShakeKeys.get(reason) ?? 0}
+          ></ve-validation-message>
+        `)}
+        ${this.messages.map(({id, reason, animationKey}) => html`
+          <ve-validation-message
+            .reason=${reason}
+            .animated=${true}
+            .animationKey=${animationKey}
+            data-message-id="${id}"
+          ></ve-validation-message>
+        `)}
+      </div>
+    `;
+  }
+
+  /**
+   * @param {string} reason
+   * @api
+   */
+  show(reason) {
+    if (!reason) {
+      return;
+    }
+
+    if (this.validationErrors.includes(reason)) {
+      this.validationErrorShakeKeys.set(reason, (this.validationErrorShakeKeys.get(reason) ?? 0) + 1);
+      this.requestUpdate();
+      return;
+    }
+
+    const animationDuration = 2000;
+    const existingMessage = this.messages.find((message) => message.reason === reason);
+    const messageId = existingMessage ? existingMessage.id : ++this.messageId;
+
+    if (existingMessage) {
+      this.messages = this.messages.map((message) => {
+        if (message.id !== messageId) {
+          return message;
+        }
+
+        return {
+          ...message,
+          animationKey: message.animationKey + 1,
+        };
+      });
+    } else {
+      this.messages = [...this.messages, {id: messageId, reason, animationKey: 0}];
+    }
+
+    this.#notifyStateChange();
+
+    const existingTimeout = this.clearTimeouts.get(messageId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+    }
+
+    this.clearTimeouts.set(messageId, setTimeout(() => {
+      this.#removeDeniedInputMessage(messageId);
+    }, animationDuration * 2));
+  }
+
+  /**
+   * @api
+   */
+  clear() {
+    for (const timeout of this.clearTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+    this.clearTimeouts.clear();
+    this.messages = [];
+    this.#notifyStateChange();
+  }
+
+  disconnectedCallback() {
+    this.clear();
+    super.disconnectedCallback();
+  }
+
+  /**
+   * @param {number} messageId
+   */
+  #removeDeniedInputMessage(messageId) {
+    const timeout = this.clearTimeouts.get(messageId);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.clearTimeouts.delete(messageId);
+    }
+
+    this.messages = this.messages.filter((message) => message.id !== messageId);
+    this.#notifyStateChange();
+  }
+
+  #notifyStateChange() {
+    this.dispatchEvent(new CustomEvent('denied-input-state-change', {
+      detail: {
+        active: this.messages.length > 0,
+        count: this.messages.length,
+      },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      z-index: 10;
+      pointer-events: none;
+    }
+
+    .messageOverlay {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+  `;
+}
+
+customElements.define('ve-validation-overlay', VeValidationOverlay);

--- a/Resources/Public/JavaScript/Frontend/flip-insert-before.test.js
+++ b/Resources/Public/JavaScript/Frontend/flip-insert-before.test.js
@@ -1,0 +1,140 @@
+import test, {afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {flipInsertBefore} from './flip-insert-before.js';
+
+const originalWindow = globalThis.window;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+afterEach(() => {
+  globalThis.window = originalWindow;
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+});
+
+function createAnimatedNode(name, rects) {
+  let index = 0;
+  const node = {
+    name,
+    style: {},
+    isConnected: false,
+    listeners: {},
+    getBoundingClientRect() {
+      const rect = rects[Math.min(index, rects.length - 1)];
+      index++;
+      return rect;
+    },
+    addEventListener(type, callback) {
+      this.listeners[type] = callback;
+    },
+    removeEventListener(type, callback) {
+      if (this.listeners[type] === callback) {
+        delete this.listeners[type];
+      }
+    },
+  };
+
+  return node;
+}
+
+function createParent(children = []) {
+  const parent = {
+    children,
+    insertCalls: [],
+    insertBefore(node, child) {
+      this.insertCalls.push([node, child]);
+      const currentIndex = this.children.indexOf(node);
+      if (currentIndex !== -1) {
+        this.children.splice(currentIndex, 1);
+      }
+
+      const insertIndex = child === null ? this.children.length : this.children.indexOf(child);
+      if (insertIndex === -1) {
+        this.children.push(node);
+      } else {
+        this.children.splice(insertIndex, 0, node);
+      }
+
+      node.parentNode = this;
+      return node;
+    },
+    getBoundingClientRect() {
+      return {left: 0, top: 0, width: 100, height: 20};
+    },
+  };
+
+  for (const child of children) {
+    child.parentNode = parent;
+  }
+
+  return parent;
+}
+
+test('flipInsertBefore throws when parent is missing', () => {
+  assert.throws(() => flipInsertBefore(null, {}), /requires at least parent and node/);
+});
+
+test('flipInsertBefore uses the reduced-motion fast path', () => {
+  globalThis.window = {
+    matchMedia(query) {
+      assert.equal(query, '(prefers-reduced-motion: reduce)');
+      return {matches: true};
+    },
+  };
+
+  const node = {};
+  const child = {};
+  const parent = createParent();
+
+  const result = flipInsertBefore(parent, node, child);
+
+  assert.equal(result, node);
+  assert.deepEqual(parent.insertCalls, [[node, child]]);
+});
+
+test('flipInsertBefore appends when the child does not belong to the parent', () => {
+  globalThis.window = {
+    matchMedia() {
+      return {matches: false};
+    },
+  };
+
+  const sibling = createAnimatedNode('sibling', [
+    {left: 0, top: 0, width: 0, height: 0},
+  ]);
+  const node = createAnimatedNode('node', [
+    {left: 0, top: 0, width: 0, height: 0},
+  ]);
+  const foreignChild = {parentNode: {}};
+  const parent = createParent([sibling]);
+
+  const result = flipInsertBefore(parent, node, foreignChild);
+
+  assert.equal(result, node);
+  assert.deepEqual(parent.children, [sibling, node]);
+  assert.deepEqual(parent.insertCalls, [[node, null]]);
+});
+
+test('flipInsertBefore returns without scheduling animation when nothing moved', () => {
+  globalThis.window = {
+    matchMedia() {
+      return {matches: false};
+    },
+  };
+  globalThis.requestAnimationFrame = () => {
+    throw new Error('animation should not be scheduled');
+  };
+
+  const first = createAnimatedNode('first', [
+    {left: 0, top: 0, width: 100, height: 20},
+    {left: 0, top: 0, width: 100, height: 20},
+  ]);
+  const second = createAnimatedNode('second', [
+    {left: 0, top: 30, width: 100, height: 20},
+    {left: 0, top: 30, width: 100, height: 20},
+  ]);
+  const parent = createParent([first, second]);
+
+  const result = flipInsertBefore(parent, first, second);
+
+  assert.equal(result, first);
+  assert.deepEqual(parent.children, [first, second]);
+});

--- a/Resources/Public/JavaScript/Frontend/initialize-save-handling.js
+++ b/Resources/Public/JavaScript/Frontend/initialize-save-handling.js
@@ -2,39 +2,48 @@ import {onMessage, sendMessage} from '@typo3/visual-editor/Shared/iframe-messagi
 import {useDataHandler} from '@typo3/visual-editor/Frontend/use-data-handler';
 import {dataHandlerStore} from '@typo3/visual-editor/Frontend/stores/data-handler-store';
 
+let saving = false;
+
+export function syncEditorState() {
+  sendMessage('updateEditorState', {
+    count: dataHandlerStore.changesCount,
+    invalidCount: dataHandlerStore.invalidCount,
+  });
+}
+
+export function focusFirstInvalidField() {
+  document.querySelector('ve-editable-text[invalid]')?.focusEditable?.();
+}
+
+export async function trySave() {
+  const count = dataHandlerStore.changesCount;
+  const invalidCount = dataHandlerStore.invalidCount;
+  if (invalidCount > 0) {
+    syncEditorState();
+    focusFirstInvalidField();
+    return;
+  }
+
+  if (saving || count === 0) {
+    return;
+  }
+
+  saving = true;
+  sendMessage('onSave');
+
+  try {
+    const updatePageTree = dataHandlerStore.hasChangesIn('pages');
+    await useDataHandler(dataHandlerStore.data, dataHandlerStore.cmdArray);
+    dataHandlerStore.markSaved();
+    sendMessage('saveEnded', {updatePageTree});
+  } finally {
+    saving = false;
+  }
+}
+
 export function initializeSaveHandling() {
-  let saving = false;
-  let count = dataHandlerStore.changesCount;
-
-  const syncCount = () => {
-    sendMessage('change', dataHandlerStore.changesCount);
-    if (dataHandlerStore.changesCount === count) {
-      return;
-    }
-    count = dataHandlerStore.changesCount;
-    sendMessage('updateChangesCount', count);
-  };
-
-  const trySave = async () => {
-    if (saving || count === 0) {
-      return;
-    }
-
-    saving = true;
-    sendMessage('onSave');
-
-    try {
-      const updatePageTree = dataHandlerStore.hasChangesIn('pages');
-      await useDataHandler(dataHandlerStore.data, dataHandlerStore.cmdArray);
-      dataHandlerStore.markSaved();
-      sendMessage('saveEnded', {updatePageTree});
-    } finally {
-      saving = false;
-    }
-  };
-
-  sendMessage('updateChangesCount', count);
-  dataHandlerStore.addEventListener('change', syncCount);
+  syncEditorState();
+  dataHandlerStore.addEventListener('change', syncEditorState);
   document.addEventListener('keydown', (event) => {
     if (!((event.ctrlKey || event.metaKey) && event.key === 's')) {
       return;

--- a/Resources/Public/JavaScript/Frontend/stores/data-handler-store.js
+++ b/Resources/Public/JavaScript/Frontend/stores/data-handler-store.js
@@ -1,14 +1,14 @@
-import {getObjectLeafCount} from '@typo3/visual-editor/Shared/get-object-leaf-count';
+import {getObjectLeafCount} from '../../Shared/get-object-leaf-count.js';
 
 /**
- * @method addEventListener(type: 'change', listener: (event: CustomEvent<{data: Object, cmd Object}>) => void): void
+ * @method addEventListener(type: 'change', listener: (event: CustomEvent<{scope: 'field'|'table'|'global', kind: 'data'|'initial'|'invalid'|'cmd'|'saved', table?: string, uid?: number, field?: string}>) => void): void
  */
 class DataHandlerStore extends EventTarget {
 
   #data = {};
   #initialData = {};
   #cmdArray = [];
-  #oldDetail = {};
+  #invalidFields = {};
 
   constructor() {
     super();
@@ -32,9 +32,22 @@ class DataHandlerStore extends EventTarget {
     return structuredClone(this.#cmdArray);
   }
 
+  get invalidFields() {
+    return structuredClone(this.#invalidFields);
+  }
 
   get changesCount() {
-    return getObjectLeafCount(this.data) + this.getCmdChanges();
+    return getObjectLeafCount(this.#data) + this.getCmdChanges();
+  }
+
+  get invalidCount() {
+    let count = 0;
+    for (const tables of Object.values(this.#invalidFields)) {
+      for (const fields of Object.values(tables)) {
+        count += Object.keys(fields).length;
+      }
+    }
+    return count;
   }
 
   /**
@@ -45,10 +58,19 @@ class DataHandlerStore extends EventTarget {
    * @return {void}
    */
   setInitialData(table, uid, field, value) {
+    if (this.#initialData[table]?.[uid]?.[field] === value) {
+      return;
+    }
+
     this.#initialData[table] = this.#initialData[table] || {};
     this.#initialData[table][uid] = this.#initialData[table][uid] || {};
     this.#initialData[table][uid][field] = value;
-    this.updateAndNotify();
+
+    if (this.#data[table]?.[uid]?.[field] === value) {
+      this.#deleteDataField(table, uid, field);
+    }
+
+    this.#dispatchChange({scope: 'field', kind: 'initial', table, uid, field});
   }
 
   /**
@@ -59,10 +81,23 @@ class DataHandlerStore extends EventTarget {
    * @return {void}
    */
   setData(table, uid, field, value) {
+    if (this.#data[table]?.[uid]?.[field] === value) {
+      return;
+    }
+
+    if (this.#data[table]?.[uid]?.[field] === undefined && this.#initialData[table]?.[uid]?.[field] === value) {
+      return;
+    }
+
     this.#data[table] = this.#data[table] || {};
     this.#data[table][uid] = this.#data[table][uid] || {};
     this.#data[table][uid][field] = value;
-    this.updateAndNotify();
+
+    if (this.#initialData[table]?.[uid]?.[field] === value) {
+      this.#deleteDataField(table, uid, field);
+    }
+
+    this.#dispatchChange({scope: 'field', kind: 'data', table, uid, field});
   }
 
   /**
@@ -80,7 +115,7 @@ class DataHandlerStore extends EventTarget {
         },
       },
     });
-    this.updateAndNotify();
+    this.#dispatchChange({scope: 'table', kind: 'cmd', table, uid});
   }
 
   markSaved() {
@@ -95,43 +130,8 @@ class DataHandlerStore extends EventTarget {
 
     this.#data = {};
     this.#cmdArray = [];
-    this.updateAndNotify();
-    // send change event as updateAndNotify skips it when there are "no changes"
-    this.dispatchEvent(new CustomEvent('change'));
-  }
-
-  updateAndNotify() {
-    // remove everything from #data that is equal to initialData
-    this.#removeStaleData();
-
-    const detail = {data: this.data, cmd: this.cmdArray};
-
-    const oldDetail = this.#oldDetail;
-    this.#oldDetail = detail;
-    if (JSON.stringify(oldDetail) === JSON.stringify(detail)) {
-      return;
-    }
-    this.dispatchEvent(new CustomEvent('change'));
-  }
-
-  #removeStaleData() {
-    for (const table in this.#data) {
-      for (const uid in this.#data[table]) {
-        for (const fieldName in this.#data[table][uid]) {
-          if (this.#initialData[table] &&
-            this.#initialData[table][uid] &&
-            this.#initialData[table][uid][fieldName] === this.#data[table][uid][fieldName]) {
-            delete this.#data[table][uid][fieldName];
-          }
-        }
-        if (Object.keys(this.#data[table][uid]).length === 0) {
-          delete this.#data[table][uid];
-        }
-      }
-      if (Object.keys(this.#data[table]).length === 0) {
-        delete this.#data[table];
-      }
-    }
+    this.#invalidFields = {};
+    this.#dispatchChange({scope: 'global', kind: 'saved'});
   }
 
   /**
@@ -142,6 +142,42 @@ class DataHandlerStore extends EventTarget {
    */
   hasChangedData(table, uid, field) {
     return !!(this.#data[table] !== undefined && this.#data[table][uid] !== undefined && this.#data[table][uid][field] !== undefined);
+  }
+
+  /**
+   * @param {string} table
+   * @param {number} uid
+   * @param {string} field
+   * @param {boolean} hasErrors
+   * @return {void}
+   */
+  setInvalid(table, uid, field, hasErrors) {
+    hasErrors = hasErrors ? true : undefined;
+    const currentValue = this.#invalidFields[table]?.[uid]?.[field];
+
+    if (currentValue === hasErrors) {
+      return;
+    }
+
+    if (!hasErrors) {
+      if (currentValue === undefined) {
+        return;
+      }
+
+      delete this.#invalidFields[table][uid][field];
+      if (Object.keys(this.#invalidFields[table][uid]).length === 0) {
+        delete this.#invalidFields[table][uid];
+      }
+      if (Object.keys(this.#invalidFields[table]).length === 0) {
+        delete this.#invalidFields[table];
+      }
+    } else {
+      this.#invalidFields[table] = this.#invalidFields[table] || {};
+      this.#invalidFields[table][uid] = this.#invalidFields[table][uid] || {};
+      this.#invalidFields[table][uid][field] = hasErrors;
+    }
+
+    this.#dispatchChange({scope: 'field', kind: 'invalid', table, uid, field});
   }
 
   getCmdChanges() {
@@ -157,6 +193,24 @@ class DataHandlerStore extends EventTarget {
       return true;
     }
     return this.#cmdArray.findIndex((cmd) => cmd[table] !== undefined) !== -1;
+  }
+
+  #dispatchChange(detail) {
+    this.dispatchEvent(new CustomEvent('change', {detail}));
+  }
+
+  #deleteDataField(table, uid, field) {
+    if (this.#data[table]?.[uid]?.[field] === undefined) {
+      return;
+    }
+
+    delete this.#data[table][uid][field];
+    if (Object.keys(this.#data[table][uid]).length === 0) {
+      delete this.#data[table][uid];
+    }
+    if (Object.keys(this.#data[table]).length === 0) {
+      delete this.#data[table];
+    }
   }
 }
 

--- a/Resources/Public/JavaScript/Frontend/stores/data-handler-store.test.js
+++ b/Resources/Public/JavaScript/Frontend/stores/data-handler-store.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+async function loadFreshStore() {
+  globalThis.window = {
+    addEventListener() {},
+  };
+  const moduleUrl = new URL(`./data-handler-store.js?test=${Math.random()}`, import.meta.url);
+  return import(moduleUrl.href);
+}
+
+test('data handler store emits scoped field details and skips no-op mutations', async () => {
+  const {dataHandlerStore} = await loadFreshStore();
+  const events = [];
+
+  dataHandlerStore.addEventListener('change', (event) => {
+    events.push(event.detail);
+  });
+
+  dataHandlerStore.setInitialData('tt_content', 123, 'header', 'Initial');
+  dataHandlerStore.setInitialData('tt_content', 123, 'header', 'Initial');
+  dataHandlerStore.setData('tt_content', 123, 'header', 'Initial');
+  dataHandlerStore.setData('tt_content', 123, 'header', 'Changed');
+  dataHandlerStore.setData('tt_content', 123, 'header', 'Changed');
+  dataHandlerStore.setInvalid('tt_content', 123, 'header', true);
+  dataHandlerStore.setInvalid('tt_content', 123, 'header', true);
+  assert.equal(dataHandlerStore.invalidCount, 1);
+  assert.deepEqual(dataHandlerStore.invalidFields, {
+    tt_content: {
+      123: {
+        header: true,
+      },
+    },
+  });
+
+  dataHandlerStore.setInvalid('tt_content', 123, 'header', false);
+  dataHandlerStore.setInvalid('tt_content', 123, 'header', false);
+
+  assert.equal(dataHandlerStore.invalidCount, 0);
+  assert.deepEqual(dataHandlerStore.invalidFields, {});
+
+  assert.deepEqual(events, [
+    {scope: 'field', kind: 'initial', table: 'tt_content', uid: 123, field: 'header'},
+    {scope: 'field', kind: 'data', table: 'tt_content', uid: 123, field: 'header'},
+    {scope: 'field', kind: 'invalid', table: 'tt_content', uid: 123, field: 'header'},
+    {scope: 'field', kind: 'invalid', table: 'tt_content', uid: 123, field: 'header'},
+  ]);
+});
+
+test('data handler store emits table and global events for commands and save', async () => {
+  const {dataHandlerStore} = await loadFreshStore();
+  const events = [];
+
+  dataHandlerStore.addEventListener('change', (event) => {
+    events.push(event.detail);
+  });
+
+  dataHandlerStore.setInitialData('tt_content', 456, 'bodytext', '<p>Initial</p>');
+  dataHandlerStore.setData('tt_content', 456, 'bodytext', '<p>Changed</p>');
+  dataHandlerStore.addCmd('tt_content', 456, 'delete', 1);
+
+  assert.equal(dataHandlerStore.changesCount, 2);
+
+  dataHandlerStore.markSaved();
+
+  assert.equal(dataHandlerStore.changesCount, 0);
+  assert.deepEqual(events.at(-2), {
+    scope: 'table',
+    kind: 'cmd',
+    table: 'tt_content',
+    uid: 456,
+  });
+  assert.deepEqual(events.at(-1), {
+    scope: 'global',
+    kind: 'saved',
+  });
+});

--- a/Resources/Public/JavaScript/Shared/get-object-leaf-count.test.js
+++ b/Resources/Public/JavaScript/Shared/get-object-leaf-count.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {getObjectLeafCount} from '@typo3/visual-editor/Shared/get-object-leaf-count';
+import {getObjectLeafCount} from './get-object-leaf-count.js';
 
 // Simple flat object
 test('getObjectLeafCount counts leaves in a flat object', () => {

--- a/Resources/Public/JavaScript/Shared/iframe-messaging.js
+++ b/Resources/Public/JavaScript/Shared/iframe-messaging.js
@@ -3,13 +3,12 @@
  * @property openModal {{ src: String, title: String, size: 'medium' | 'large' | 'full', type: 'iframe' | 'ajax' }}
  * @property closeModal {null}
  * @property reloadFrames {null}
- * @property updateChangesCount {number}
+ * @property updateEditorState {{count: number, invalidCount: number}}
  * @property doSave {null}
  * @property onSave {null}
  * @property saveEnded {{updatePageTree: boolean}}
  * @property pageChanged {{pageId: number, languageId: number}}
  * @property openInMiddleFrame {String}
- * @property change {Number}
  * @property localStoreChange {{key: String, value: any}}
  * @property localStoreRequest {String}
  */

--- a/Resources/Public/JavaScript/Shared/remove-rule-by-selector.test.js
+++ b/Resources/Public/JavaScript/Shared/remove-rule-by-selector.test.js
@@ -1,0 +1,94 @@
+import test, {afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {removeRuleBySelector} from './remove-rule-by-selector.js';
+
+const originalCSSStyleRule = globalThis.CSSStyleRule;
+
+afterEach(() => {
+  globalThis.CSSStyleRule = originalCSSStyleRule;
+});
+
+class FakeCSSStyleRule {
+  constructor(selectorText, cssText = 'color: red;') {
+    this.selectorText = selectorText;
+    this.style = {cssText};
+  }
+}
+
+function createSheet(rules) {
+  return {
+    cssRules: [...rules],
+    deleteRule(index) {
+      this.cssRules.splice(index, 1);
+    },
+    insertRule(rule, index) {
+      this.cssRules.splice(index, 0, rule);
+    },
+  };
+}
+
+test('removeRuleBySelector removes a full matching rule', () => {
+  globalThis.CSSStyleRule = FakeCSSStyleRule;
+
+  const sheet = createSheet([
+    new FakeCSSStyleRule('.match'),
+    new FakeCSSStyleRule('.keep'),
+  ]);
+  const root = {styleSheets: [sheet]};
+
+  const removed = removeRuleBySelector('.match', root);
+
+  assert.equal(removed, 1);
+  assert.equal(sheet.cssRules.length, 1);
+  assert.equal(sheet.cssRules[0].selectorText, '.keep');
+});
+
+test('removeRuleBySelector rewrites grouped rules and preserves declarations', () => {
+  globalThis.CSSStyleRule = FakeCSSStyleRule;
+
+  const sheet = createSheet([
+    new FakeCSSStyleRule('.match, .keep', 'display: block;'),
+  ]);
+  const root = {styleSheets: [sheet]};
+
+  const removed = removeRuleBySelector('.match', root);
+
+  assert.equal(removed, 1);
+  assert.deepEqual(sheet.cssRules, ['.keep { display: block; }']);
+});
+
+test('removeRuleBySelector recurses into grouping rules', () => {
+  globalThis.CSSStyleRule = FakeCSSStyleRule;
+
+  const nestedGroup = createSheet([
+    new FakeCSSStyleRule('.match'),
+    new FakeCSSStyleRule('.other'),
+  ]);
+  const sheet = createSheet([nestedGroup]);
+  const root = {styleSheets: [sheet]};
+
+  const removed = removeRuleBySelector('.match', root);
+
+  assert.equal(removed, 1);
+  assert.equal(nestedGroup.cssRules.length, 1);
+  assert.equal(nestedGroup.cssRules[0].selectorText, '.other');
+});
+
+test('removeRuleBySelector skips unreadable stylesheets', () => {
+  globalThis.CSSStyleRule = FakeCSSStyleRule;
+
+  const root = {
+    styleSheets: [
+      {
+        get cssRules() {
+          throw new Error('SecurityError');
+        },
+      },
+      createSheet([new FakeCSSStyleRule('.match')]),
+    ],
+  };
+
+  const removed = removeRuleBySelector('.match', root);
+
+  assert.equal(removed, 1);
+});

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     ],
     "post-autoload-dump": [
       "sh -c 'MAJOR=$(typo3 --version | awk '\\''{split($3, v, \".\"); print v[1]}'\\''); ln -sfn \"phpstan-baseline-${MAJOR}.neon\" phpstan-baseline.neon'"
-    ]
+    ],
+    "test:js": "node --test $(find Resources/Public/JavaScript -name \"*.test.js\" | sort)"
   }
 }


### PR DESCRIPTION
Expose supported TCA validation rules for editable text fields in the visual editor frontend.

Apply required, min, max, and supported eval rules during inline editing, show validation feedback directly in the editor, and prevent save actions while fields still contain invalid values.