### PR TITLE
[BUGFIX] allow inline style attributes in mutated CSP policy

### DIFF
--- a/Classes/EventListener/PolicyMutatedEventListener.php
+++ b/Classes/EventListener/PolicyMutatedEventListener.php
@@ -33,5 +33,10 @@ final readonly class PolicyMutatedEventListener
         // add style-src 'unsafe-inline' to allow a working ckeditor in the frontend.
         $mutation = new Mutation(MutationMode::Extend, Directive::StyleSrc, SourceKeyword::self, SourceKeyword::unsafeInline);
         $event->getCurrentPolicy()->mutate($mutation);
+
+        if ($event->getCurrentPolicy()->get(Directive::StyleSrcAttr)) {
+            $mutation = new Mutation(MutationMode::Extend, Directive::StyleSrcAttr, SourceKeyword::unsafeInline);
+            $event->getCurrentPolicy()->mutate($mutation);
+        }
     }
 }


### PR DESCRIPTION
Extend `style-src-attr` with `'unsafe-inline'` when the directive exists so frontend editing keeps working under CSP setups that split inline styles between `style-src` and `style-src-attr`.

Fixes #34 

We always need the StyleSrcAttr to also be unsafe-inline to make ckeditor work :/ 