### PR TITLE
[BUGFIX] Use getParsedBody() instead of decoding request body stream

### DIFF
--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -66,7 +66,7 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             throw new UnauthorizedException('Invalid or missing request token', 8148623595);
         }
 
-        $input = json_decode($request->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+        $input = $request->getParsedBody();
 
         $data = $input['data'] ?? [];
         unset($input['data']);


### PR DESCRIPTION
PSR-7 streams are one-time readable; getParsedBody() avoids empty reads.