### PR TITLE
[BUGFIX] stop loading RTE contents CSS into the visual editor frontend

### DIFF
--- a/Classes/ViewHelpers/Render/TextViewHelper.php
+++ b/Classes/ViewHelpers/Render/TextViewHelper.php
@@ -16,7 +16,6 @@ use TYPO3\CMS\Core\Schema\Field\InputFieldType;
 use TYPO3\CMS\Core\Schema\Field\TextFieldType;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Fluid\ViewHelpers\Format\HtmlViewHelper;
 use TYPO3\CMS\Frontend\Page\PageInformation;
@@ -32,7 +31,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 use function get_debug_type;
 use function htmlspecialchars;
-use function is_array;
 use function is_int;
 use function is_string;
 use function json_encode;
@@ -54,8 +52,6 @@ use const JSON_THROW_ON_ERROR;
 final class TextViewHelper extends AbstractViewHelper
 {
     private const RECORD_TYPE = RecordInterface::class . '|' . PageInformation::class . '|' . DomainObjectInterface::class;
-
-    private const DEFAULT_RTE_CONTENTS_CSS_RESOURCE = 'EXT:rte_ckeditor/Resources/Public/Css/contents.css';
 
     /**
      * Extbase models have a __toString() method and Fluid calls that if we escape the Children (arguments)
@@ -309,23 +305,6 @@ final class TextViewHelper extends AbstractViewHelper
         );
 
         $config = $this->richTextConfigurationService->resolveCkEditorConfiguration($richTextConfigurationServiceDto);
-        if (is_array($config['contentsCss'] ?? null)) {
-            $defaultRteContentsCss = PathUtility::getAbsoluteWebPath(
-                GeneralUtility::createVersionNumberedFilename(
-                    GeneralUtility::getFileAbsFileName(self::DEFAULT_RTE_CONTENTS_CSS_RESOURCE),
-                ),
-            );
-            $contentsCss = [];
-            foreach ($config['contentsCss'] as $path) {
-                if (is_string($path) && $path === $defaultRteContentsCss) {
-                    continue;
-                }
-
-                $contentsCss[] = $path;
-            }
-
-            $config['contentsCss'] = $contentsCss;
-        }
 
         unset($config['height']); // height is set by the content itself and css
         $config['debug'] = false; // for now we disable debug mode

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ You need to be Logged in to every Domain separately to use the Visual Editor.
 
 OR you can use [EXT:multisite_belogin](https://extensions.typo3.org/extension/multisite_belogin) it automatically logs you in to all sites/domains.
 
+## Rich Text Styling
+
+Visual Editor uses your regular frontend CSS for the editing view. CSS that is configured only in the TYPO3 RTE configuration (`contentsCss`) is not applied there.
+
+If your project defines custom rich-text styles, add the relevant rules to your frontend CSS so the page output and the editor share the same styling. Projects with custom `lib.parseFunc_RTE` setups may also need matching frontend rules.
+
 ## License and Authors: License type, contributors, contact information
 
 This extension is licensed under the [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) license.

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
@@ -2,7 +2,6 @@ import {LitElement} from 'lit';
 import {ClassicEditor as Editor} from '@ckeditor/ckeditor5-editor-classic';
 // import {InlineEditor as Editor} from '@ckeditor/ckeditor5-editor-inline'; // TODO fix issues with inline editor
 import {initCKEditorInstance} from '@typo3/rte-ckeditor/init-ckeditor-instance.js';
-import {prefixAndRebaseCss} from '@typo3/rte-ckeditor/css-prefixer.js';
 import {removeRuleBySelector} from '@typo3/visual-editor/Shared/remove-rule-by-selector';
 import {dataHandlerStore} from '@typo3/visual-editor/Frontend/stores/data-handler-store';
 import {showEmptyActive} from '@typo3/visual-editor/Shared/local-stores';
@@ -68,8 +67,6 @@ export class VeEditableRichText extends LitElement {
     }
     element.appendChild(wrapper);
 
-    this.includeCssScoped(this.options.contentsCss);
-
     this.editor = await initCKEditorInstance(this.options || {}, wrapper, wrapper, Editor);
     this.editor.editing.view.document.getRoot('main').placeholder = this.placeholder;
     this.editor.model.document.on('change:data', () => {
@@ -97,58 +94,6 @@ export class VeEditableRichText extends LitElement {
       this.style.display = '';
       this.parentElement.display = '';
     }
-  }
-
-  /**
-   * @param {string[]} contentsCss
-   */
-  async includeCssScoped(contentsCss) {
-    if (!contentsCss) {
-      return;
-    }
-    // set id to this if not already present
-    if (!this.dataset.cssHash) {
-      // hash of contentsCss using SubtleCrypto.digest()
-      this.dataset.cssHash = 've-' + await this.hash(contentsCss.join(','));
-    }
-
-    // skip if there already is a stylesheet with this id
-    if (document.adoptedStyleSheets.some(sheet => sheet.cssHash === this.dataset.cssHash)) {
-      return;
-    }
-
-    let completeCss = '';
-
-    const scopedSheet = new CSSStyleSheet();
-    scopedSheet.name = `Scoped styles for ${this.dataset.cssHash}`;
-    scopedSheet.cssHash = this.dataset.cssHash;
-    scopedSheet.replaceSync(completeCss);
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, scopedSheet];
-
-    const promisesArray = contentsCss.map(async url => {
-      try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Status ' + response.status);
-        }
-        const cssContent = await response.text();
-        const cssPrefixed = prefixAndRebaseCss(cssContent, url, [`[data-css-hash=${this.dataset.cssHash}]`]);
-        completeCss += cssPrefixed;
-        scopedSheet.replaceSync(completeCss);
-      } catch (error) {
-        console.error(`Failed to fetch CSS content for CKEditor 5 prefixing: "${url}"`, error);
-      }
-    });
-
-    await Promise.allSettled(promisesArray);
-  }
-
-  /**
-   * @param {string} input
-   * @return {Promise<string>}
-   */
-  async hash(input) {
-    return new Uint8Array(await crypto.subtle.digest('SHA-1', new TextEncoder().encode(input))).toHex();
   }
 
   #onDataHandlerChange(event) {


### PR DESCRIPTION
Use the regular frontend CSS as the styling base for inline rich-text editing.

Remove the extra contents CSS injection and the default-contents filtering logic so the editor matches the rendered page more predictably. Document that projects with custom rich-text styling need matching frontend CSS rules.

fixes: #42 