### PR TITLE
[BUGFIX] allow non-admin editors to open the visual editor

### DIFF
--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -473,7 +473,7 @@ final class PageEditController
 
         $isEditLocked = false;
         if ($this->schema->hasCapability(TcaSchemaCapability::EditLock)) {
-            $isEditLocked = $this->pageRecord->get($this->schema->getCapability(TcaSchemaCapability::EditLock)->getFieldName()) ?? false;
+            $isEditLocked = $this->pageRecord->getRawRecord()->get($this->schema->getCapability(TcaSchemaCapability::EditLock)->getFieldName()) ?? false;
         }
 
         if ($isEditLocked) {

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -8,11 +8,9 @@ return [
     'frontend' => [
         'typo3/cms-visual-editor/persistence-middleware' => [
             'target' => PersistenceMiddleware::class,
-            'before' => [
-                'typo3/cms-frontend/prepare-tsfe-rendering',
-            ],
             'after' => [
-                'typo3/cms-frontend/tsfe',
+                'typo3/cms-frontend/prepare-tsfe-rendering',
+                'typo3/cms-frontend/tsfe', // TODO typo3/cms-frontend/tsfe can be dropped if TYPO3 14 is lowest supported version
                 'typo3/cms-frontend/page-resolver',
                 'typo3/cms-adminpanel/sql-logging',
             ],


### PR DESCRIPTION
Build page edit iframe URLs from TYPO3's preview URI builder so the
editor follows the same access simulation as the regular preview.

This fixes editing on pages that depend on frontend group or time-based
preview parameters.