### PR TITLE
[BUGFIX] allow trailing spaces while editing trimmed text

### DIFF
--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -383,7 +383,9 @@ export class VeEditableText extends LitElement {
       return;
     }
 
-    const {text, reasons} = normalizeValue(edit.insertedText, this.validation);
+    const {text, reasons} = normalizeValue(edit.insertedText, this.validation, {
+      preserveLeadingAndTrailingWhitespace: true,
+    });
     let insertedText = text;
 
     for (const reason of reasons) {

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.js
@@ -5,17 +5,21 @@
 /**
  * @param {string} input
  * @param {Record<string, any>} validation
+ * @param {{preserveLeadingAndTrailingWhitespace?: boolean}} [options]
  * @returns {{text: string, reasons: ValidationMessage[]}}
  */
-export function normalizeValue(input, validation) {
+export function normalizeValue(input, validation, options = {}) {
   let text = input;
   const reasons = [];
+  const preserveLeadingAndTrailingWhitespace = options.preserveLeadingAndTrailingWhitespace === true;
 
   const evalList = Array.isArray(validation?.eval) ? validation.eval : [];
   for (const evalName of evalList) {
     switch (evalName) {
       case 'trim':
-        text = text.trim();
+        if (!preserveLeadingAndTrailingWhitespace) {
+          text = text.trim();
+        }
         break;
       case 'upper':
         text = text.toLocaleUpperCase();

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.test.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text/validation.test.js
@@ -9,6 +9,24 @@ test('normalizeValue trims before later validation checks are applied', () => {
   assert.deepEqual(result.reasons, []);
 });
 
+test('normalizeValue keeps leading and trailing whitespace during live input', () => {
+  const result = normalizeValue(' ab ', {eval: ['trim']}, {
+    preserveLeadingAndTrailingWhitespace: true,
+  });
+
+  assert.equal(result.text, ' ab ');
+  assert.deepEqual(result.reasons, []);
+});
+
+test('normalizeValue still applies non-trim eval rules during live input', () => {
+  const result = normalizeValue(' a ', {eval: ['trim', 'upper']}, {
+    preserveLeadingAndTrailingWhitespace: true,
+  });
+
+  assert.equal(result.text, ' A ');
+  assert.deepEqual(result.reasons, []);
+});
+
 test('getValidationIssues uses original text for required validation', () => {
   const issues = getValidationIssues('   ', {eval: ['trim'], required: true});
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-iframe-popup.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-iframe-popup.js
@@ -30,6 +30,9 @@ export class VeIframePopup extends LitElement {
 
 
   static styles = css`
+        :host {
+          padding: 5px;
+        }
         button {
             cursor: pointer;
             display: inline-flex;


### PR DESCRIPTION
Keep `eval=trim` from removing leading and trailing whitespace during live input. The value is still normalized when it is stored, so editors can type naturally without changing the saved result.

fixes #53 