### PR TITLE
[TASK] keep empty editable fields highlighted

### DIFF
--- a/Resources/Public/Css/editable.css
+++ b/Resources/Public/Css/editable.css
@@ -20,6 +20,12 @@
   outline: 0.25rem solid #5432fe !important;
 }
 
+ve-editable-rich-text[empty] .ck-content {
+  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.50) inset !important;
+  backdrop-filter: blur(10px) invert(20%) !important;
+  outline: 0.25rem solid #5432fe !important;
+}
+
 ve-editable-rich-text[changed] .ck-content {
   backdrop-filter: blur(10px) hue-rotate(120deg) invert(30%) !important;
 }
@@ -45,6 +51,15 @@ ve-editable-rich-text[changed] .ck-content {
   /*color: var(--ck-content-font-color); !* TODO fix this if color is white we want to use white *!*/
 }
 
+/* hide placeholder if focused */
+.ck.ck-editor__editable.ck-focused > .ck-placeholder::before,
+.ck.ck-editor__editable.ck-focused .ck-placeholder::before {
+  display: none;
+}
+
+.ck-placeholder {
+  font-style: italic;
+}
 
 #typo3-preview-info {
   /*  hide the preview info box, as it is not relevant for the editor and only distracts from the content */

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-rich-text.js
@@ -15,6 +15,7 @@ import {dragInProgressStore} from '@typo3/visual-editor/Frontend/stores/drag-sto
 export class VeEditableRichText extends LitElement {
   static properties = {
     changed: {type: Boolean, reflect: true},
+    empty: {type: Boolean, reflect: true},
     value: {type: String, reflect: true},
 
     name: {type: String},
@@ -35,6 +36,7 @@ export class VeEditableRichText extends LitElement {
   constructor() {
     super();
     this.value = this.innerHTML;
+    this.empty = this.value === '';
     this.showEmpty = showEmptyActive.get();
     this.onDataHandlerChange = this.#onDataHandlerChange.bind(this);
     this.onShowEmptyChange = this.#onShowEmptyChange.bind(this);
@@ -58,7 +60,7 @@ export class VeEditableRichText extends LitElement {
   }
 
   async firstUpdated() {
-    this.placeholder = '👀' + (this.placeholder || this.title);
+    this.placeholder = this.name;
     /** @type {HTMLElement} */
     const element = this;
     const wrapper = document.createElement('div');
@@ -71,10 +73,12 @@ export class VeEditableRichText extends LitElement {
     this.editor.editing.view.document.getRoot('main').placeholder = this.placeholder;
     this.editor.model.document.on('change:data', () => {
       this.value = this.editor.getData({ skipListItemIds: true });
+      this.empty = this.value === '';
       dataHandlerStore.setData(this.table, this.uid, this.field, this.value);
       this.changed = dataHandlerStore.hasChangedData(this.table, this.uid, this.field);
     });
     this.value = this.editor.getData({ skipListItemIds: true });
+    this.empty = this.value === '';
     dataHandlerStore.setInitialData(this.table, this.uid, this.field, this.value);
 
     // reset CSS
@@ -84,6 +88,7 @@ export class VeEditableRichText extends LitElement {
   }
 
   updated(changedProperties) {
+    this.empty = this.value === '';
     const hideEmpty = !this.showEmpty && this.value === '' && !this.matches(':focus-within') && !this.changed;
     if (hideEmpty) {
       this.style.display = 'none';
@@ -105,6 +110,7 @@ export class VeEditableRichText extends LitElement {
     const storedValue = dataHandlerStore.data[this.table]?.[this.uid]?.[this.field] ?? undefined;
     if (storedValue?.trim() !== this.editor?.getData({ skipListItemIds: true })?.trim()) {
       this.value = storedValue ?? this.value;
+      this.empty = this.value === '';
       this.editor?.setData(this.value);
     }
   }

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -103,7 +103,7 @@ export class VeEditableText extends LitElement {
    * @param changedProperties {Map<PropertyKey, unknown>}
    */
   firstUpdated(changedProperties) {
-    this.placeholder = '👀' + this.title;
+    this.placeholder = this.name;
     this.skipNextValueNormalization = true;
     this.#setSlotText(this.valueInitial);
     dataHandlerStore.setInitialData(this.table, this.uid, this.field, this.valueInitial);
@@ -189,11 +189,13 @@ export class VeEditableText extends LitElement {
 
     const slot = this.shadowRoot?.querySelector('.slot');
     const showPlaceholder = !this.focused && !(slot?.innerText || this.value).length;
+    const isEmpty = this.value === '';
     return html`
       <span
         class=${classMap({
           slot: true,
           changed: this.changed,
+          empty: isEmpty,
           invalid: this.invalid,
           block: !shouldBeInline,
         })}
@@ -559,6 +561,12 @@ export class VeEditableText extends LitElement {
     }
 
     .slot:hover, .slot:focus {
+      box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.50) inset;
+      backdrop-filter: blur(10px) invert(20%);
+      outline-color: #5432fe;
+    }
+
+    .slot.empty {
       box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.50) inset;
       backdrop-filter: blur(10px) invert(20%);
       outline-color: #5432fe;


### PR DESCRIPTION
Keep the purple border visible for editable text and rich-text fields while they remain empty.

This makes empty fields easier to spot in the visual editor until content is entered again.