### PR TITLE
[BUGFIX] Try getParsedBody() before decoding request body stream

### DIFF
--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -66,7 +66,8 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             throw new UnauthorizedException('Invalid or missing request token', 8148623595);
         }
 
-        $input = json_decode($request->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+        $input = $request->getParsedBody() ??
+            json_decode($request->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 
         $data = $input['data'] ?? [];
         unset($input['data']);


### PR DESCRIPTION
PSR-7 streams are one-time readable; getParsedBody() avoids empty reads.

This is only relevant if you use a middleware like: https://github.com/middlewares/payload/blob/a6f8109397368c0fb79af044a6bd5c6d90166b72/src/JsonPayload.php

thanks to @twojtylak