### PR TITLE
[FEATURE] remember the backend page tree state across editor reloads

### DIFF
--- a/Resources/Public/JavaScript/Backend/index.js
+++ b/Resources/Public/JavaScript/Backend/index.js
@@ -5,7 +5,9 @@ import '@typo3/visual-editor/Backend/components/ve-backend-save-button';
 import '@typo3/visual-editor/Backend/components/ve-spotlight-toggle';
 import '@typo3/visual-editor/Backend/components/ve-show-empty-toggle';
 import {pageChanged} from '@typo3/visual-editor/Backend/page-changed';
+import {initializePageTreeSaveState} from '@typo3/visual-editor/Backend/initialize-page-tree-save-state';
 
+initializePageTreeSaveState();
 
 function reloadAllChildFrames() {
   const iframes = document.querySelectorAll('iframe');

--- a/Resources/Public/JavaScript/Backend/initialize-page-tree-save-state.js
+++ b/Resources/Public/JavaScript/Backend/initialize-page-tree-save-state.js
@@ -1,0 +1,25 @@
+export function initializePageTreeSaveState() {
+  if (!window.top.veDoNotRegisterStateChangeListenerForPageTree) {
+    // for internal page reloads (middle Iframe) we do not want to change the state of the navigation state.
+    window.top.veDoNotRegisterStateChangeListenerForPageTree = true;
+
+    window.top.document.addEventListener('typo3:content-navigation:state-change', () => {
+      const element = document.querySelector('typo3-backend-content-navigation-toggle');
+      const isOpen = element.hidden;
+      const shouldBeOpen = sessionStorage.getItem('ve-page-tree-open') === 'true';
+      // XOR to check if the state is different, if so, toggle it by clicking the button
+      if (isOpen ^ shouldBeOpen) {
+        element.click();
+      }
+    }, {once: true});
+  }
+
+  // save state
+  window.top.document.addEventListener('typo3:content-navigation:state-change', () => {
+    setTimeout(() => {
+      const element = document.querySelector('typo3-backend-content-navigation-toggle');
+      const isOpen = element.hidden;
+      sessionStorage.setItem('ve-page-tree-open', isOpen);
+    });
+  });
+}


### PR DESCRIPTION
Persist the page tree open state in session storage and restore it after TYPO3 fires the content navigation state change event.