### PR TITLE
[TASK] Improve drag-scroll smoothness

### DIFF
--- a/Resources/Public/JavaScript/Frontend/components/ve-drag-handle.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-drag-handle.js
@@ -1,6 +1,7 @@
 import {css, LitElement} from 'lit';
 import {dragInProgressStore} from '@typo3/visual-editor/Frontend/stores/drag-store';
 import {autoNoOverlap} from '@typo3/visual-editor/Frontend/auto-no-overlap';
+import {initVelocityScroll} from '@typo3/visual-editor/Frontend/components/ve-drag-handle/velocity-scroll';
 
 /**
  * @extends {HTMLElement}
@@ -57,6 +58,8 @@ export class VeDragHandle extends LitElement {
 
     dragInProgressStore.value = info;
     this.#autoScroll(event.clientX, event.clientY);
+
+    this.velocityScroll = initVelocityScroll();
   }
 
   /**
@@ -84,76 +87,50 @@ export class VeDragHandle extends LitElement {
    */
   #dragEnd(event) {
     dragInProgressStore.value = false;
+    this.velocityScroll?.destroy();
   }
 
   #autoScroll(clientX, clientY) {
-    if (clientX == null || clientY == null) {
-      return;
-    }
-
-    const verticalEdgeOfWindow = window.innerHeight * 0.20;
-    const horizontalEdgeOfWindow = window.innerWidth * 0.20;
-    const maxVerticalScrollStrength = window.innerHeight * 0.6;
-    const maxHorizontalScrollStrength = window.innerWidth * 0.6;
+    const verticalEdgeOfWindow = window.innerHeight * 0.2;
+    const horizontalEdgeOfWindow = window.innerWidth * 0.2;
+    const maxVerticalScrollStrength = window.innerHeight * 2.5;
+    const maxHorizontalScrollStrength = window.innerWidth * 2.5;
     // scroll zone progress goes from 0 to 1:
     // 0 means the cursor just entered the scroll zone,
     // 1 means the cursor is at the viewport edge
     const maxProgress = 1;
-    const viewportHeight = window.innerHeight;
-    const viewportWidth = window.innerWidth;
-    const scrollingElement = document.scrollingElement;
-    if (!scrollingElement) {
-      return;
-    }
     let verticalScrollAmount = 0;
     let horizontalScrollAmount = 0;
 
     // from the mouse position, calculate the distance to each viewport edge
     const distanceToTop = clientY;
-    const distanceToBottom = viewportHeight - clientY;
+    const distanceToBottom = window.innerHeight - clientY;
     const distanceToLeft = clientX;
-    const distanceToRight = viewportWidth - clientX;
+    const distanceToRight = window.innerWidth - clientX;
 
     // the closer the cursor is to the viewport edge, the stronger the scroll becomes
     // We calculate a progress value and square it (** 2) so scrolling accelerates more near the edge
     if (distanceToBottom < verticalEdgeOfWindow) {
       const progressInBottomZone = maxProgress - distanceToBottom / verticalEdgeOfWindow;
-      verticalScrollAmount = Math.ceil((progressInBottomZone ** 2) * maxVerticalScrollStrength);
+      verticalScrollAmount = ((progressInBottomZone ** 2) * maxVerticalScrollStrength);
     }
 
     if (distanceToTop < verticalEdgeOfWindow) {
       const progressInTopZone = maxProgress - distanceToTop / verticalEdgeOfWindow;
-      verticalScrollAmount = -Math.ceil((progressInTopZone ** 2) * maxVerticalScrollStrength);
+      verticalScrollAmount = -((progressInTopZone ** 2) * maxVerticalScrollStrength);
     }
 
     if (distanceToRight < horizontalEdgeOfWindow) {
       const progressInRightZone = maxProgress - distanceToRight / horizontalEdgeOfWindow;
-      horizontalScrollAmount = Math.ceil((progressInRightZone ** 2) * maxHorizontalScrollStrength);
+      horizontalScrollAmount = ((progressInRightZone ** 2) * maxHorizontalScrollStrength);
     }
 
     if (distanceToLeft < horizontalEdgeOfWindow) {
       const progressInLeftZone = maxProgress - distanceToLeft / horizontalEdgeOfWindow;
-      horizontalScrollAmount = -Math.ceil((progressInLeftZone ** 2) * maxHorizontalScrollStrength);
+      horizontalScrollAmount = -((progressInLeftZone ** 2) * maxHorizontalScrollStrength);
     }
 
-    if (!verticalScrollAmount && !horizontalScrollAmount) {
-      return;
-    }
-
-    const newVerticalScrollPosition = scrollingElement.scrollTop + verticalScrollAmount;
-    const maxVerticalScrollPosition = scrollingElement.scrollHeight - viewportHeight;
-    const limitedVerticalScrollPosition = Math.max(0, Math.min(newVerticalScrollPosition, maxVerticalScrollPosition));
-    const newHorizontalScrollPosition = scrollingElement.scrollLeft + horizontalScrollAmount;
-    const maxHorizontalScrollPosition = scrollingElement.scrollWidth - viewportWidth;
-    const limitedHorizontalScrollPosition = Math.max(0, Math.min(newHorizontalScrollPosition, maxHorizontalScrollPosition));
-
-    // in firefox we only can set one of the both scrollTop and scrollLeft to them taking effect, so we select that really needs updating
-    if (limitedVerticalScrollPosition !== Math.ceil(scrollingElement.scrollTop)) {
-      scrollingElement.scrollTop = limitedVerticalScrollPosition;
-    }
-    if (limitedHorizontalScrollPosition !== Math.ceil(scrollingElement.scrollLeft)) {
-      scrollingElement.scrollLeft = limitedHorizontalScrollPosition;
-    }
+    this.velocityScroll?.setVelocity(verticalScrollAmount, horizontalScrollAmount);
   }
 
   createRenderRoot() {

--- a/Resources/Public/JavaScript/Frontend/components/ve-drag-handle/velocity-scroll.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-drag-handle/velocity-scroll.js
@@ -1,0 +1,53 @@
+import {dragInProgressStore} from '@typo3/visual-editor/Frontend/stores/drag-store';
+
+export function initVelocityScroll() {
+
+  let scrollSpeedVertical = 0;
+  let scrollSpeedHorizontal = 0;
+
+  let active = true;
+
+  let lastFrameTime = Date.now();
+  const interval = () => {
+
+    const fps = 1000 / (Date.now() - lastFrameTime);
+    lastFrameTime = Date.now();
+
+    const oldSmoothScrollingBehavior = document.scrollingElement.style.scrollBehavior;
+    document.scrollingElement.style.scrollBehavior = 'auto';
+
+    const newVerticalScrollPosition = document.scrollingElement.scrollTop + scrollSpeedVertical / fps;
+    const maxVerticalScrollPosition = document.scrollingElement.scrollHeight - window.innerHeight;
+    const limitedVerticalScrollPosition = Math.max(0, Math.min(newVerticalScrollPosition, maxVerticalScrollPosition));
+    const newHorizontalScrollPosition = document.scrollingElement.scrollLeft + scrollSpeedHorizontal / fps;
+    const maxHorizontalScrollPosition = document.scrollingElement.scrollWidth - window.innerWidth;
+    const limitedHorizontalScrollPosition = Math.max(0, Math.min(newHorizontalScrollPosition, maxHorizontalScrollPosition));
+
+    if (limitedVerticalScrollPosition) {
+      document.scrollingElement.scrollTop = limitedVerticalScrollPosition;
+    }
+    if (limitedHorizontalScrollPosition) {
+      document.scrollingElement.scrollLeft = limitedHorizontalScrollPosition;
+    }
+    document.scrollingElement.style.scrollBehavior = oldSmoothScrollingBehavior;
+
+    if (active) {
+      requestAnimationFrame(interval);
+    }
+  }
+  interval();
+
+  return {
+    /**
+     * @param verticalPixelPerSecond {Number}
+     * @param horizontalPixelPerSecond {Number}
+     */
+    setVelocity(verticalPixelPerSecond, horizontalPixelPerSecond) {
+      scrollSpeedVertical = verticalPixelPerSecond;
+      scrollSpeedHorizontal = horizontalPixelPerSecond;
+    },
+    destroy() {
+      active = false;
+    },
+  };
+}


### PR DESCRIPTION
Keep drag auto-scroll running independently from pointermove events. This avoids choppy edge scrolling and makes long drag operations feel smoother.