### PR TITLE
[BGUFIX] fix call to getGroupedRecords

### DIFF
--- a/Classes/Service/LanguageModeService.php
+++ b/Classes/Service/LanguageModeService.php
@@ -33,7 +33,7 @@ final readonly class LanguageModeService
 
         if ($this->typo3Version->getMajorVersion() >= 14) {
             $pageLayout = $pageInformation->getPageLayout() ?? throw new InvalidArgumentException('PageLayout is not available in PageInformation', 1772464934);
-            $groupedRecords = $pageLayout->getContentAreas()->getGroupedRecords();
+            $groupedRecords = $pageLayout->getContentAreas()->getGroupedRecords($request);
         } else {
             $groupedRecords = $this->getGroupedRecordsTYPO3v13($pageInformation->getPageRecord(), $request);
         }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "b13/container": "^3.2.3",
     "pluswerk/grumphp-config": "^10.2.6",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
-    "ssch/typo3-rector": "^3.13.0",
+    "ssch/typo3-rector": "^3.14.1",
     "typo3fluid/fluid": "^4.6.0 || 4.6.x-dev || ^5"
   },
   "suggest": {


### PR DESCRIPTION
Internal method getGroupedRecords on ContentAreaCollection changed signature. We now need to give in a ServerRequestInterface Object.