### PR TITLE
[BUGFIX] handle DataHandler save errors without breaking the editor

### DIFF
--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -78,10 +78,14 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             throw new RuntimeException('Unknown data operations: ' . implode(', ', array_keys($input)) . ' only data and cmdArray are allowed', 8110225095);
         }
 
-        $this->dataHandlerService->run($data, []);
+        $errorLog = $this->dataHandlerService->run($data, []);
 
         foreach ($cmdArray as $cmd) {
-            $this->dataHandlerService->run([], $cmd);
+            $errorLog = [...$errorLog, ...$this->dataHandlerService->run([], $cmd)];
+        }
+
+        if ($errorLog) {
+            return new JsonResponse(['success' => false, 'errorLog' => $errorLog], 500);
         }
 
         return new JsonResponse(['success' => true]);

--- a/Classes/Service/DataHandlerService.php
+++ b/Classes/Service/DataHandlerService.php
@@ -9,8 +9,6 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function count;
-use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
@@ -25,8 +23,10 @@ final readonly class DataHandlerService
     /**
      * @param array<string, array<int, array<string, bool|int|float|string>>> $data
      * @param array<string, array<int, array<string, mixed>>> $cmd
+     *
+     * @return list<string>
      */
-    public function run(array $data, array $cmd): void
+    public function run(array $data, array $cmd): array
     {
         $this->validateData($data);
         $this->validateCmd($cmd);
@@ -35,11 +35,7 @@ final readonly class DataHandlerService
         $dataHandler->start($data, $cmd);
         $dataHandler->process_datamap();
         $dataHandler->process_cmdmap();
-        if (count($dataHandler->errorLog) > 0) {
-            throw new RuntimeException('Error running DataHandler: ' . implode(', ', $dataHandler->errorLog), 4718411495);
-        }
-
-        unset($dataHandler);
+        return $dataHandler->errorLog;
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -23,6 +23,9 @@
       <trans-unit id="save.changes">
         <target>%d Änderungen speichern</target>
       </trans-unit>
+      <trans-unit id="save.failed">
+        <target>Fehler beim Speichern</target>
+      </trans-unit>
       <trans-unit id="save.fixInvalidField">
         <target>1 Fehler beheben</target>
       </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -23,6 +23,9 @@
       <trans-unit id="save.changes">
         <source>Save %d changes</source>
       </trans-unit>
+      <trans-unit id="save.failed">
+        <source>Error while saving</source>
+      </trans-unit>
       <trans-unit id="save.fixInvalidField">
         <source>Fix an error</source>
       </trans-unit>

--- a/Resources/Public/JavaScript/Frontend/initialize-save-handling.js
+++ b/Resources/Public/JavaScript/Frontend/initialize-save-handling.js
@@ -33,9 +33,12 @@ export async function trySave() {
 
   try {
     const updatePageTree = dataHandlerStore.hasChangesIn('pages');
-    await useDataHandler(dataHandlerStore.data, dataHandlerStore.cmdArray);
+    const saveOk = await useDataHandler(dataHandlerStore.data, dataHandlerStore.cmdArray);
     dataHandlerStore.markSaved();
     sendMessage('saveEnded', {updatePageTree});
+    if (!saveOk) {
+      window.location.reload();
+    }
   } finally {
     saving = false;
   }

--- a/Resources/Public/JavaScript/Frontend/use-data-handler.js
+++ b/Resources/Public/JavaScript/Frontend/use-data-handler.js
@@ -1,9 +1,12 @@
+import Notification from '@typo3/backend/notification.js';
+import {lll} from "@typo3/core/lit-helper.js";
+
 /**
  * @typedef {Record<string, Record<number, Record<string, boolean|number|string>>>} Data
  * @typedef {Record<string, Record<number, Record<'move'|'copy'|'delete', any>>>} Cmd
  * @param {Data} data
  * @param {Cmd[]} cmdArray
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} returns false if something broke
  */
 export async function useDataHandler(data = {}, cmdArray = []) {
   const response = await fetch(window.location.href, {
@@ -14,9 +17,28 @@ export async function useDataHandler(data = {}, cmdArray = []) {
     },
     body: JSON.stringify({data, cmdArray}, null, 2),
   });
-  if (!response.ok) {
-    // TODO handle innerHTML differently, (maybe return json exception with message and details instead of whole HTML)
-    document.body.innerHTML = await response.text();
-    throw new Error('Failed to save data');
+
+  if (response.ok) {
+    return true;
   }
+
+  let body = await response.text();
+
+  // if response has json parse it and check if errorLog is included:
+  if (response.headers.get('Content-Type')?.includes('application/json')) {
+    const data = JSON.parse(body);
+    if (data.errorLog) {
+      for (const error of data.errorLog) {
+        Notification.error(lll('save.failed'), error);
+      }
+      return false;
+    }
+    const pre = document.createElement("PRE");
+    pre.innerText = JSON.stringify(data, null, 2);
+    body = pre.outerHTML;
+  }
+
+  // TODO handle innerHTML differently, (maybe return json exception with message and details instead of whole HTML)
+  document.body.innerHTML = body;
+  throw new Error('Failed to save data');
 }

--- a/phpstan-baseline-13.neon
+++ b/phpstan-baseline-13.neon
@@ -149,3 +149,9 @@ parameters:
 			identifier: method.notFound
 			count: 4
 			path: Classes/PhpStanRule/NamedArgumentUsageRule.php
+
+		-
+			message: '#^Method TYPO3\\CMS\\VisualEditor\\Service\\DataHandlerService\:\:run\(\) should return list\<string\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/Service/DataHandlerService.php

--- a/phpstan-baseline-14.neon
+++ b/phpstan-baseline-14.neon
@@ -19,6 +19,12 @@ parameters:
 			path: Classes/PhpStanRule/NamedArgumentUsageRule.php
 
 		-
+			message: '#^Method TYPO3\\CMS\\VisualEditor\\Service\\DataHandlerService\:\:run\(\) should return list\<string\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/Service/DataHandlerService.php
+
+		-
 			message: '#^Cannot access offset ''allowed\.'' on TYPO3\\CMS\\Core\\Page\\ContentArea\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1


### PR DESCRIPTION
Return DataHandler error messages from the persistence middleware and show them as backend notifications in the frontend save flow.

This keeps known save failures visible to the editor user and reloads the page afterwards so the UI can recover from a broken save state.

related #66 