### PR TITLE
[FEATURE] make images editable

### DIFF
--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TYPO3\CMS\VisualEditor\Service;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -23,6 +24,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
+use function array_merge_recursive;
 use function method_exists;
 
 final readonly class EditModeService
@@ -85,18 +87,9 @@ final readonly class EditModeService
                 throw new RuntimeException('Could not determine current site language', 3305745963);
             }
 
-            $routing = $request->getAttribute('routing');
-            if (!$routing instanceof PageArguments) {
-                throw new RuntimeException('Could not determine current routing context', 1773230232);
-            }
-
             $isExtContainerInstalled = ExtensionManagementUtility::isLoaded('container');
 
-            $backendEditUrl = (string)$this->uriBuilder->buildUriFromRoute('web_edit', [
-                'id' => $pageId,
-                'languages' => [$siteLanguage->getLanguageId()],
-                'params' => $routing->getRouteArguments(),
-            ]);
+            $backendEditUrl = $this->getBackendEditUrl($request);
 
             $newContentUrl = (string)$this->uriBuilder->buildUriFromRoute('new_content_element_wizard', [
                 'id' => $pageId,
@@ -125,7 +118,7 @@ final readonly class EditModeService
                 'editContentContextualUrl' => $editContentContextualUrl ?? null,
                 'allowNewContent' => $this->languageModeService->getAllowNewContent($pageInformation, $siteLanguage, $request),
                 'token' => $this->formProtectionFactory->createForType('backend')->generateToken('visual_editor', 'save'),
-                'routeArguments' => (object)$this->flattenBracketKeys(['params' => $routing->getRouteArguments()]),
+                'routeArguments' => (object)$this->flattenBracketKeys(['params' => $this->getUsedArguments($request)]),
                 'allowedOrigins' => $this->getAllowedOrigins(),
             ];
             $this->assetCollector->addInlineJavaScript(
@@ -257,5 +250,50 @@ if (window.parent === window && window.veInfo) {
         }
 
         return array_keys($allowed);
+    }
+
+    public function getBackendEditUrl(ServerRequestInterface $request): UriInterface
+    {
+        // backend and Frontend Context: determine current page id
+        $pageInformation = $request->getAttribute('frontend.page.information');
+        if (!$pageInformation instanceof PageInformation) {
+            throw new RuntimeException('Could not determine current page information', 9965439961);
+        }
+
+        $pageId = $pageInformation->getId();
+        if (!$pageId) {
+            throw new RuntimeException('Could not determine current page id', 1768983081);
+        }
+
+        $siteLanguage = $request->getAttribute('language');
+        if (!$siteLanguage instanceof SiteLanguage) {
+            throw new RuntimeException('Could not determine current site language', 3305745963);
+        }
+
+        $usedArguments = $this->getUsedArguments($request);
+        return $this->uriBuilder->buildUriFromRoute('web_edit', [
+            'id' => $pageId,
+            'languages' => [$siteLanguage->getLanguageId()],
+            'params' => $usedArguments,
+        ]);
+    }
+
+    /**
+     * @return array<string|array<string|array<mixed>>>
+     */
+    private function getUsedArguments(ServerRequestInterface $request): array
+    {
+        $routing = $request->getAttribute('routing');
+        if (!$routing instanceof PageArguments) {
+            throw new RuntimeException('Could not determine current routing context', 1773230232);
+        }
+
+        $usedArguments = array_merge_recursive(
+            $routing->getArguments(),
+            $routing->getRouteArguments(),
+        );
+        unset($usedArguments['cHash']);
+        unset($usedArguments['editMode']);
+        return $usedArguments;
     }
 }

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\ViewHelpers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
+use RuntimeException;
+use Throwable;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Extbase\Service\ImageService;
+use TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper as CoreImageViewHelper;
+use TYPO3\CMS\VisualEditor\Service\EditModeService;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+use function htmlspecialchars;
+use function json_encode;
+
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
+use const JSON_THROW_ON_ERROR;
+
+final class ImageViewHelper extends AbstractTagBasedViewHelper
+{
+    /**
+     * We shadow TYPO3's core f:image and delegate rendering to the core ViewHelper.
+     * Only the data-veedit enrichment belongs to this class.
+     *
+     * @var string
+     */
+    protected $tagName = 'img';
+
+    public function __construct(
+        private readonly UriBuilder $uriBuilder,
+        private readonly ImageService $imageService,
+        private readonly EditModeService $editModeService,
+        private readonly Typo3Version $typo3Version,
+    ) {
+        parent::__construct();
+    }
+
+    public function initializeArguments(): void
+    {
+        $reflection = new ReflectionClass(CoreImageViewHelper::class);
+        $instance = $reflection->newInstanceWithoutConstructor();
+        $instance->initializeArguments();
+
+        $this->argumentDefinitions = $instance->argumentDefinitions;
+    }
+
+    public function render(): string
+    {
+        $renderingContext = $this->renderingContext ?? throw new RuntimeException('$this->renderingContext is not available', 1772888895);
+        $renderedTag = $renderingContext->getViewHelperInvoker()->invoke(
+            CoreImageViewHelper::class,
+            array_merge($this->arguments, $this->additionalArguments),
+            $renderingContext,
+        );
+
+        if (!$this->renderingContext->hasAttribute(ServerRequestInterface::class)) {
+            return $renderedTag;
+        }
+
+        $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
+        if (!$this->editModeService->isEditMode($request)) {
+            return $renderedTag;
+        }
+
+        $visualEditorPayload = $this->buildVisualEditorPayload($request);
+        if ($visualEditorPayload === null) {
+            return $renderedTag;
+        }
+
+        $attributeValue = json_encode($visualEditorPayload, JSON_THROW_ON_ERROR);
+        return $this->injectAttribute($renderedTag, 'data-veedit', $attributeValue);
+    }
+
+    /**
+     * @return array{url: string, editUrl: string}|null
+     */
+    private function buildVisualEditorPayload(ServerRequestInterface $request): ?array
+    {
+        $image = $this->resolveImage();
+        if (!$image instanceof File && !$image instanceof FileReference) {
+            return null;
+        }
+
+        if ($image instanceof File) {
+            $fields = [];
+            $table = 'sys_file';
+            $uid = (int)$image->getProperty('uid');
+        } else {
+            $fields = [(string)$image->getProperty('fieldname')];
+            $table = (string)$image->getProperty('tablenames');
+            $uid = (int)$image->getProperty('uid_foreign');
+        }
+
+        if ($uid <= 0 || $table === '') {
+            return null;
+        }
+
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        if (!$normalizedParams instanceof NormalizedParams) {
+            return null;
+        }
+
+        $backendEditUrl = (string)$this->editModeService->getBackendEditUrl($request);
+        $editParams = [
+            'edit' => [$table => [$uid => 'edit']],
+            'columnsOnly' => [$table => $fields],
+            'returnUrl' => $backendEditUrl,
+        ];
+
+        $url = '';
+        if ($this->typo3Version->getMajorVersion() >= 14) {
+            $url = (string)$this->uriBuilder->buildUriFromRoute('record_edit_contextual', $editParams);
+        }
+
+        return [
+            'url' => $url,
+            'editUrl' => (string)$this->uriBuilder->buildUriFromRoute('record_edit', $editParams),
+        ];
+    }
+
+    private function resolveImage(): File|FileReference|null
+    {
+        try {
+            $image = $this->imageService->getImage(
+                (string)$this->arguments['src'],
+                $this->arguments['image'],
+                (bool)$this->arguments['treatIdAsReference'],
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        return ($image instanceof File || $image instanceof FileReference) ? $image : null;
+    }
+
+    private function injectAttribute(string $tag, string $attributeName, string $attributeValue): string
+    {
+        $tagEndPosition = strrpos($tag, '>');
+        if ($tagEndPosition === false) {
+            return $tag;
+        }
+
+        $insertPosition = $tagEndPosition;
+        if ($tagEndPosition > 0 && $tag[$tagEndPosition - 1] === '/') {
+            $insertPosition--;
+        }
+
+        return substr($tag, 0, $insertPosition)
+            . ' '
+            . $attributeName
+            . '="'
+            . htmlspecialchars($attributeValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            . '"'
+            . substr($tag, $insertPosition);
+    }
+}

--- a/Resources/Public/Css/editable.css
+++ b/Resources/Public/Css/editable.css
@@ -61,7 +61,53 @@ ve-editable-rich-text[changed] .ck-content {
   font-style: italic;
 }
 
+/**
+ * Hide the preview info box, as it is not relevant for the editor and only distracts from the content.
+ */
+
 #typo3-preview-info {
-  /*  hide the preview info box, as it is not relevant for the editor and only distracts from the content */
   display: none;
+}
+
+
+/**
+ * Image Edit overlay:
+ */
+img[data-veedit] {
+  anchor-name: --ve-image;
+  transition: filter 0.2s ease, outline-color 0.2s ease;
+  outline: 5px solid transparent;
+  outline-offset: -5px;
+  pointer-events: initial;
+
+  &:hover {
+    /*filter: brightness(0.6);*/
+    cursor: pointer;
+    outline-color: #5432fe;
+  }
+}
+
+*:has(> img[data-veedit]) {
+  anchor-scope: --ve-image;
+}
+
+*:has(> img[data-veedit])::after {
+  content: '';
+
+  position: absolute;
+  position-anchor: --ve-image;
+  position-area: center;
+
+  width: clamp(20px, 33%, 100px);
+  aspect-ratio: 1 / 1;
+  filter: drop-shadow( 0 0 0.25rem #000 ) drop-shadow( 0 0 0.5rem #000 ) drop-shadow( 0 0 0.75rem #000 );
+
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background: center / contain no-repeat url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g fill="white"><path d="m9.293 3.293-8 8A.997.997 0 0 0 1 12v3h3c.265 0 .52-.105.707-.293l8-8-3.414-3.414zM8.999 5l.5.5-5 5-.5-.5 5-5zM4 14H3v-1H2v-1l1-1 2 2-1 1zM13.707 5.707l1.354-1.354a.5.5 0 0 0 0-.707L12.354.939a.5.5 0 0 0-.707 0l-1.354 1.354 3.414 3.414z"/></g></svg>');
+}
+
+*:has(> img[data-veedit]:hover)::after {
+  opacity: 1;
 }

--- a/Resources/Public/JavaScript/Frontend/index.js
+++ b/Resources/Public/JavaScript/Frontend/index.js
@@ -13,6 +13,7 @@ import {initSaveScrollPosition} from '@typo3/visual-editor/Frontend/init-save-sc
 import {initializeCrossOriginNavigations} from '@typo3/visual-editor/Frontend/initialize-cross-origin-navigations';
 import {initializeSaveHandling} from '@typo3/visual-editor/Frontend/initialize-save-handling';
 import {initializeSpotlightHandling} from '@typo3/visual-editor/Frontend/initialize-spotlight-handling';
+import {initializeImageHandling} from '@typo3/visual-editor/Frontend/initialize-image-handling';
 
 if (window.location.hash === '#ve-close') {
   sendMessage('closeModal');
@@ -28,3 +29,4 @@ initializeSpotlightHandling();
 initializeSaveHandling();
 initSaveScrollPosition();
 initializeCrossOriginNavigations();
+initializeImageHandling();

--- a/Resources/Public/JavaScript/Frontend/initialize-image-handling.js
+++ b/Resources/Public/JavaScript/Frontend/initialize-image-handling.js
@@ -1,0 +1,30 @@
+import {sendMessage} from '@typo3/visual-editor/Shared/iframe-messaging';
+
+export function initializeImageHandling() {
+  const images = document.querySelectorAll('img[data-veedit]');
+  for (const image of images) {
+    if (!(image instanceof HTMLImageElement)) {
+      continue;
+    }
+
+    image.addEventListener('click', (e) => {
+      const data = JSON.parse(image.dataset.veedit);
+      if (!data.editUrl) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      if (!data.url) {
+        // We are in TYPO3 13 and need to open the url directly
+        sendMessage('openInMiddleFrame', data.editUrl);
+        return;
+      }
+      const tag = document.createElement('typo3-backend-contextual-record-edit-trigger');
+      tag.setAttribute('url', data.url);
+      tag.setAttribute('edit-url', data.editUrl);
+      tag.click();
+    });
+  }
+}

--- a/phpstan-baseline-13.neon
+++ b/phpstan-baseline-13.neon
@@ -124,6 +124,12 @@ parameters:
 			message: '#^Property TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:\$renderingContext \(TYPO3Fluid\\Fluid\\Core\\Rendering\\RenderingContextInterface\) on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.property
 			count: 1
+			path: Classes/ViewHelpers/ImageViewHelper.php
+
+		-
+			message: '#^Property TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:\$renderingContext \(TYPO3Fluid\\Fluid\\Core\\Rendering\\RenderingContextInterface\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
 			path: Classes/ViewHelpers/Mark/ContentAreaViewHelper.php
 
 		-


### PR DESCRIPTION
We have overwritten the `f:image` ViewHelper because we only want to manipulate `img` tags and not the URI's.

If we receive a `FileReference`, we can determine the relevant field in the original record and make it editable. This makes it possible to change the image, add another one, or remove the image completely. However, if we receive a `File` object, we can only render the sys_file record for editing.