### PR TITLE
[BUGFIX] handle doktypes with option isViewable=false without breaking the editor

### DIFF
--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -55,6 +55,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
 
 use function array_map;
 use function array_values;
@@ -97,6 +98,7 @@ final class PageEditController
         private readonly ConnectionPool $connectionPool,
         private readonly AssetCollector $assetCollector,
         private readonly Context $context,
+        private readonly PageDoktypeRegistry $pageDoktypeRegistry,
     ) {
     }
 
@@ -132,6 +134,10 @@ final class PageEditController
 
         if ($record->getRecordType() === '254') {
             throw new InvalidArgumentException('Page record is of type "folder" and cannot be edited with the Visual Editor', 5965019514);
+        }
+
+        if ($this->typo3Version->getMajorVersion() >= 14 && !$this->pageDoktypeRegistry->isPageViewable((int) $record->getRecordType(), $pageUid)) {
+            throw new InvalidArgumentException('Page record is not viewable and cannot be edited with the Visual Editor', 5965019515);
         }
 
         $this->pageRecord = $record;

--- a/phpstan-baseline-13.neon
+++ b/phpstan-baseline-13.neon
@@ -37,6 +37,12 @@ parameters:
 			path: Classes/Backend/Controller/PageEditController.php
 
 		-
+			message: '#^Call to an undefined method TYPO3\\CMS\\Core\\DataHandling\\PageDoktypeRegistry\:\:isPageViewable\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Classes/Backend/Controller/PageEditController.php
+
+		-
 			message: '#^Call to method build\(\) on an unknown class TYPO3\\CMS\\Backend\\Template\\Components\\Buttons\\LanguageSelectorBuilder\.$#'
 			identifier: class.notFound
 			count: 1
@@ -109,6 +115,18 @@ parameters:
 			path: Classes/Middleware/PersistenceMiddleware.php
 
 		-
+			message: '#^Call to an undefined method PhpParser\\Node\\Expr\|PhpParser\\Node\\Identifier\:\:toString\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: Classes/PhpStanRule/NamedArgumentUsageRule.php
+
+		-
+			message: '#^Method TYPO3\\CMS\\VisualEditor\\Service\\DataHandlerService\:\:run\(\) should return list\<string\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/Service/DataHandlerService.php
+
+		-
 			message: '#^Cannot call method getGroupedRecords\(\) on array\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -143,15 +161,3 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: ext_localconf.php
-
-		-
-			message: '#^Call to an undefined method PhpParser\\Node\\Expr\|PhpParser\\Node\\Identifier\:\:toString\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: Classes/PhpStanRule/NamedArgumentUsageRule.php
-
-		-
-			message: '#^Method TYPO3\\CMS\\VisualEditor\\Service\\DataHandlerService\:\:run\(\) should return list\<string\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/Service/DataHandlerService.php


### PR DESCRIPTION
Add Check for TYPO3 >= 14 if doktype is Viewable.

Doktypes with this option set to false are not rendered in the frontend. This check disables the Editor using the same logic as already used for the page type "folder".

See: https://github.com/FriendsOfTYPO3/visual_editor/issues/71
