### PR TITLE
[TASK] Use `SystemResourceFactory` instead of deprecated functions

### DIFF
--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -677,9 +677,12 @@ final class PageEditController
             ->setLabel($languageService->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.language'))
             ->setShowLabelText(true);
 
-        $pageTranslations = BackendUtility::getExistingPageTranslations($this->pageRecord->getUid());
         $languageField = $this->schema->getCapability(TcaSchemaCapability::Language)->getLanguageField()->getName();
+
+        // @extensionScannerIgnoreLine will be removed after TYPO3 v13 support is dropped
+        $pageTranslations = BackendUtility::getExistingPageTranslations($this->pageRecord->getUid());
         $translationLanguageUids = array_map(fn(array $pageTranslation): int => (int)$pageTranslation[$languageField], $pageTranslations);
+
         $translationLanguageUids[] = 0;
 
         foreach ($this->availableLanguages as $language) {

--- a/Classes/Core/RichtText/RichTextConfigurationService.php
+++ b/Classes/Core/RichtText/RichTextConfigurationService.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace TYPO3\CMS\VisualEditor\Core\RichtText;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\Locales;
+use TYPO3\CMS\Core\SystemResource\Publishing\SystemResourcePublisherInterface;
+use TYPO3\CMS\Core\SystemResource\Publishing\UriGenerationOptions;
+use TYPO3\CMS\Core\SystemResource\SystemResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\RteCKEditor\Form\Element\Event\AfterGetExternalPluginsEvent;
@@ -31,6 +37,7 @@ readonly class RichTextConfigurationService
         private EventDispatcher $eventDispatcher,
         private UriBuilder $uriBuilder,
         private Locales $locales,
+        private Typo3Version $typo3Version,
     ) {
     }
 
@@ -225,13 +232,29 @@ readonly class RichTextConfigurationService
      */
     protected function resolveUrlPath(string $value): string
     {
-        if (str_contains($value, '?')) {
-            return PathUtility::getPublicResourceWebPath($value);
+        if ($this->typo3Version->getMajorVersion() < 14) {
+            if (str_contains($value, '?')) {
+                // @extensionScannerIgnoreLine
+                return PathUtility::getPublicResourceWebPath($value);
+            }
+
+            $value = GeneralUtility::getFileAbsFileName($value);
+            // @extensionScannerIgnoreLine
+            $value = GeneralUtility::createVersionNumberedFilename($value);
+            return PathUtility::getAbsoluteWebPath($value);
         }
 
-        $value = GeneralUtility::getFileAbsFileName($value);
-        $value = GeneralUtility::createVersionNumberedFilename($value);
-        return PathUtility::getAbsoluteWebPath($value);
+        return $this->resolveUrlPathV14($value, $GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals());
+    }
+
+    public function resolveUrlPathV14(string $resourceIdentifier, ServerRequestInterface $request): string
+    {
+        // TODO use DI if TYPO3 14 is the minimum requirement
+        $systemResourceFactory = GeneralUtility::makeInstance(SystemResourceFactory::class);
+        $systemResourcePublisherInterface = GeneralUtility::makeInstance(SystemResourcePublisherInterface::class);
+
+        $resource = $systemResourceFactory->createPublicResource($resourceIdentifier);
+        return (string)$systemResourcePublisherInterface->generateUri($resource, $request, new UriGenerationOptions(absoluteUri: true));
     }
 
     protected function getBackendUser(): BackendUserAuthentication

--- a/Tests/Functional/Fixtures/Extensions/blog_example/ext_localconf.php
+++ b/Tests/Functional/Fixtures/Extensions/blog_example/ext_localconf.php
@@ -15,7 +15,8 @@ ExtensionUtility::configurePlugin(
     [
         BlogController::class => ['list', 'details', 'testSingle', 'testForm', 'testForward', 'testForwardTarget', 'testRelatedObject'],
     ],
-    pluginType: ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+    [],
+    ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
 );
 ExtensionUtility::configurePlugin(
     'BlogExample',
@@ -23,7 +24,8 @@ ExtensionUtility::configurePlugin(
     [
         ContentController::class => ['list'],
     ],
-    pluginType: ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+    [],
+    ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
 );
 ExtensionUtility::configurePlugin(
     'BlogExample',
@@ -34,5 +36,5 @@ ExtensionUtility::configurePlugin(
     [
         BlogPostEditingController::class => ['list', 'view', 'edit', 'persist', 'new', 'create'],
     ],
-    pluginType: ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+    ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
 );

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "friendsoftypo3/visual-editor",
-  "description": "TYPO3 CMS Visual Editor - brings a modern WYSIWYG editing experience to TYPO3 CMS.",
+  "description": "TYPO3 CMS Visual Editor - Brings a modern WYSIWYG editing experience to TYPO3 CMS.",
   "license": [
     "GPL-2.0-or-later"
   ],
@@ -31,10 +31,10 @@
     "pluswerk/grumphp-config": "^10.2.7",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
     "ssch/typo3-rector": "^3.14.1",
-    "typo3/cms-install": "^13.4.0 || ^14.3.0",
-    "typo3/cms-workspaces": "^13.4.0 || ^14.3.0",
+    "typo3/cms-install": "^13.4.28 || ^14.3.0",
+    "typo3/cms-workspaces": "^13.4.28 || ^14.3.0",
     "typo3/testing-framework": "^9.5.0",
-    "typo3fluid/fluid": "^4.6.0 || ^5.3.1"
+    "typo3fluid/fluid": "^4.6.1 || ^5.3.1"
   },
   "suggest": {
     "wapplersystems/multisite-belogin": "You should install this extension, if you have multiple domains in your TYPO3 installation."

--- a/phpstan-baseline-13.neon
+++ b/phpstan-baseline-13.neon
@@ -13,6 +13,12 @@ parameters:
 			path: Classes/Backend/Controller/PageEditController.php
 
 		-
+			message: '#^Call to an undefined method TYPO3\\CMS\\Backend\\Domain\\Repository\\Localization\\LocalizationRepository\:\:getPageTranslations\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Classes/Backend/Controller/PageEditController.php
+
+		-
 			message: '#^Call to an undefined method TYPO3\\CMS\\Backend\\Template\\Components\\DocHeaderComponent\:\:disableAutomaticReloadButton\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -67,10 +73,46 @@ parameters:
 			path: Classes/Backend/Controller/PageEditController.php
 
 		-
+			message: '#^Comparison operation "\<\=" between int\<min, 13\> and 13 is always true\.$#'
+			identifier: smallerOrEqual.alwaysTrue
+			count: 1
+			path: Classes/Backend/Controller/PageEditController.php
+
+		-
 			message: '#^Property TYPO3\\CMS\\VisualEditor\\Backend\\Controller\\PageEditController\:\:\$moduleData \(TYPO3\\CMS\\Backend\\Module\\ModuleData\) does not accept TYPO3\\CMS\\Backend\\Module\\ModuleData\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: Classes/Backend/Controller/PageEditController.php
+
+		-
+			message: '#^Call to method createPublicResource\(\) on an unknown class TYPO3\\CMS\\Core\\SystemResource\\SystemResourceFactory\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/Core/RichtText/RichTextConfigurationService.php
+
+		-
+			message: '#^Call to method generateUri\(\) on an unknown class TYPO3\\CMS\\Core\\SystemResource\\Publishing\\SystemResourcePublisherInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/Core/RichtText/RichTextConfigurationService.php
+
+		-
+			message: '#^Class TYPO3\\CMS\\Core\\SystemResource\\Publishing\\SystemResourcePublisherInterface not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/Core/RichtText/RichTextConfigurationService.php
+
+		-
+			message: '#^Class TYPO3\\CMS\\Core\\SystemResource\\SystemResourceFactory not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/Core/RichtText/RichTextConfigurationService.php
+
+		-
+			message: '#^Instantiated class TYPO3\\CMS\\Core\\SystemResource\\Publishing\\UriGenerationOptions not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/Core/RichtText/RichTextConfigurationService.php
 
 		-
 			message: '#^Call to method getContentArea\(\) on an unknown class TYPO3\\CMS\\Fluid\\Event\\ModifyRenderedContentAreaEvent\.$#'


### PR DESCRIPTION
Use `SystemResourceFactory` in v14 instead of the deprecated `PathUtility::getPublicResourceWebPath` and `GeneralUtility::createVersionNumberedFilename`.