### PR TITLE
[FEATURE] Keep TYPO3 links in edit mode

### DIFF
--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -47,7 +47,7 @@ final readonly class EditModeService
     {
         $queryParams = $request->getQueryParams();
 
-        if (!($queryParams['editMode'] ?? false)) {
+        if (!isset($queryParams['editMode'])) {
             return false;
         }
 
@@ -89,7 +89,7 @@ final readonly class EditModeService
 
             $isExtContainerInstalled = ExtensionManagementUtility::isLoaded('container');
 
-            $backendEditUrl = $this->getBackendEditUrl($request);
+            $backendEditUrl = (string)$this->getBackendEditUrl($request);
 
             $newContentUrl = (string)$this->uriBuilder->buildUriFromRoute('new_content_element_wizard', [
                 'id' => $pageId,

--- a/Resources/Public/JavaScript/Frontend/index.js
+++ b/Resources/Public/JavaScript/Frontend/index.js
@@ -10,7 +10,7 @@ import '@typo3/visual-editor/Frontend/components/ve-error';
 import '@typo3/visual-editor/Frontend/components/ve-iframe-popup';
 import {sendMessage} from '@typo3/visual-editor/Shared/iframe-messaging';
 import {initSaveScrollPosition} from '@typo3/visual-editor/Frontend/init-save-scroll-position';
-import {initializeCrossOriginNavigations} from '@typo3/visual-editor/Frontend/initialize-cross-origin-navigations';
+import {initializeNavigationInterception} from '@typo3/visual-editor/Frontend/initialize-navigation-interception';
 import {initializeSaveHandling} from '@typo3/visual-editor/Frontend/initialize-save-handling';
 import {initializeSpotlightHandling} from '@typo3/visual-editor/Frontend/initialize-spotlight-handling';
 import {initializeImageHandling} from '@typo3/visual-editor/Frontend/initialize-image-handling';
@@ -28,5 +28,5 @@ if (window.veInfo) {
 initializeSpotlightHandling();
 initializeSaveHandling();
 initSaveScrollPosition();
-initializeCrossOriginNavigations();
+initializeNavigationInterception();
 initializeImageHandling();

--- a/Resources/Public/JavaScript/Frontend/initialize-navigation-interception.js
+++ b/Resources/Public/JavaScript/Frontend/initialize-navigation-interception.js
@@ -20,7 +20,7 @@ async function resolveCrossOriginBackendUrl(url) {
   return data.url;
 }
 
-export function initializeCrossOriginNavigations() {
+export function initializeNavigationInterception() {
 
   navigation.addEventListener("navigate", (event) => {
     const newUrl = new URL(event.destination.url);
@@ -41,6 +41,14 @@ export function initializeCrossOriginNavigations() {
 
       // open in new Tab and force switch to
       window.open(event.destination.url, '_blank').focus();
+    }
+
+    // we automatically add the editMode parameter if the origin is one of the TYPO3 origins:
+    // that way we ensure that the page is opened in edit mode even if the link was not generated via TYPO3 API's
+    if (!newUrl.searchParams.has('editMode') && window.veInfo.allowedOrigins.includes(newUrl.origin)) {
+      newUrl.searchParams.set('editMode', '1');
+      event.preventDefault();
+      window.location = newUrl.toString();
     }
   });
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,3 +15,7 @@ ExtensionManagementUtility::addTypoScriptSetup("@import 'EXT:visual_editor/Confi
 if (!class_exists(ModifyRenderedContentAreaEvent::class)) {
     class_alias(V13_RenderContentAreaEvent::class, ModifyRenderedContentAreaEvent::class);
 }
+
+// exclude editMode from chash: If the parameter is present, the middleware already stops the normal rendering.
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] ??= [];
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'editMode';


### PR DESCRIPTION
Automatically preserve the visual editor context when editors follow TYPO3 links that do not already include `editMode`.

This keeps navigation inside editable frontend pages from accidentally leaving the editor while still handling allowed cross-origin TYPO3 links through the backend URL resolver.