### PR TITLE
[BUGFIX] Hide action bar when editable text loses focus

### DIFF
--- a/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
@@ -27,6 +27,7 @@ export class VeContentElement extends LitElement {
     canBeMoved: {type: Boolean},
 
     isHovered: {type: Boolean, state: true, attribute: false},
+    isFocusWithin: {type: Boolean, state: true, attribute: false},
     dragInProgress: {type: Boolean, state: true, attribute: false},
     showElementOverlay: {type: Boolean, attribute: false},
   };
@@ -79,6 +80,7 @@ export class VeContentElement extends LitElement {
   constructor() {
     super();
     this.onDragInProgressChange = this.#onDragInProgressChange.bind(this);
+    this.isFocusWithin = false;
     this.addEventListener('mouseenter', () => {
       this.isHovered = true;
       setTimeout(calculateAllDebounced);


### PR DESCRIPTION
Keep the visual editor action bar in sync with focus changes inside content elements.

This prevents the action bar from staying visible after an editable text field loses focus and the pointer has already left the element.