### PR TITLE
fix: set GLOBALS[TYPO3_REQUEST] before DataHandler in saveStuff()

### DIFF
--- a/Classes/Middleware/PersistenceMiddleware.php
+++ b/Classes/Middleware/PersistenceMiddleware.php
@@ -78,6 +78,9 @@ readonly class PersistenceMiddleware implements MiddlewareInterface
             throw new RuntimeException('Unknown data operations: ' . implode(', ', array_keys($input)) . ' only data and cmdArray are allowed', 8110225095);
         }
 
+        // Required by DefaultSanitizerBuilder when processing RTE fields via DataHandler;
+        // this middleware short-circuits before the FE RequestHandler which normally sets this global.
+        $GLOBALS['TYPO3_REQUEST'] = $request;
         $errorLog = $this->dataHandlerService->run($data, []);
 
         foreach ($cmdArray as $cmd) {


### PR DESCRIPTION
 When the Visual Editor saves content via a POST request, PersistenceMiddleware
  returns a response directly without passing control to the inner FE RequestHandler.
  That handler is the only place that sets $GLOBALS['TYPO3_REQUEST'], which
  DefaultSanitizerBuilder requires when sanitizing RTE field values via its closure.

  Without this fix, saving any content element that contains RTE fields throws:
    RuntimeException: DefaultSanitizerBuilder requires an active PSR-7 request
    with normalizedParams attribute. (code #1775675289)