### PR TITLE
[BUGFIX] Disable frontend cache in edit mode

### DIFF
--- a/Classes/Middleware/DisableCacheInEditModeMiddleware.php
+++ b/Classes/Middleware/DisableCacheInEditModeMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Frontend\Cache\CacheInstruction;
+
+readonly class DisableCacheInEditModeMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $params = $request->getQueryParams();
+        if (isset($params['editMode'])) {
+            $cacheInstruction = $request->getAttribute('frontend.cache.instruction', new CacheInstruction());
+            $cacheInstruction->disableCache('EXT:visual_editor: The editMode parameter forced the cache to be disabled.');
+            $request = $request->withAttribute('frontend.cache.instruction', $cacheInstruction);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\VisualEditor\Middleware\DisableCacheInEditModeMiddleware;
 use TYPO3\CMS\VisualEditor\Middleware\PersistenceMiddleware;
 
 return [
@@ -9,6 +10,16 @@ return [
         'typo3/cms-visual-editor/persistence-middleware' => [
             'target' => PersistenceMiddleware::class,
             'after' => [
+                'typo3/cms-frontend/prepare-tsfe-rendering',
+                'typo3/cms-frontend/tsfe', // TODO typo3/cms-frontend/tsfe can be dropped if TYPO3 14 is lowest supported version
+                'typo3/cms-frontend/page-resolver',
+                'typo3/cms-adminpanel/sql-logging',
+            ],
+        ],
+        'typo3/cms-visual-editor/disable-cache-in-edit-mode-middleware' => [
+            'target' => DisableCacheInEditModeMiddleware::class,
+            'before' => [
+                'typo3/cms-frontend/page-argument-validator',
                 'typo3/cms-frontend/prepare-tsfe-rendering',
                 'typo3/cms-frontend/tsfe', // TODO typo3/cms-frontend/tsfe can be dropped if TYPO3 14 is lowest supported version
                 'typo3/cms-frontend/page-resolver',

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "pluswerk/grumphp-config": "^10.2.7",
     "saschaegerer/phpstan-typo3": "^2.1.1 || ^3.0.1",
     "ssch/typo3-rector": "^3.14.1",
-    "typo3/cms-install": "^13.4.28 || ^14.3.0",
-    "typo3/cms-workspaces": "^13.4.28 || ^14.3.0",
+    "typo3/cms-install": "^13.4.28 || ^14.3.2",
+    "typo3/cms-workspaces": "^13.4.28 || ^14.3.2",
     "typo3/testing-framework": "^9.5.0",
     "typo3fluid/fluid": "^4.6.1 || ^5.3.1"
   },

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,7 +15,3 @@ ExtensionManagementUtility::addTypoScriptSetup("@import 'EXT:visual_editor/Confi
 if (!class_exists(ModifyRenderedContentAreaEvent::class)) {
     class_alias(V13_RenderContentAreaEvent::class, ModifyRenderedContentAreaEvent::class);
 }
-
-// exclude editMode from chash: If the parameter is present, the middleware already stops the normal rendering.
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] ??= [];
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'editMode';


### PR DESCRIPTION
Disable the frontend cache whenever the `editMode` query parameter is present.

This keeps visual editor requests from using cached page output without excluding the parameter from cHash handling globally.

fixes #89 