### PR TITLE
[FEATURE] Add "Show hidden" toggle to hide disabled content elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /public/
 /phpstan-baseline.neon
 /.codex
+/.claude
+*.local.md

--- a/Classes/Backend/Controller/PageEditController.php
+++ b/Classes/Backend/Controller/PageEditController.php
@@ -293,6 +293,11 @@ final class PageEditController
             $buttonBar->addButton($button, ButtonBar::BUTTON_POSITION_LEFT, 3);
         }
 
+        // Show Hidden Toggle
+        if ($button = $this->makeShowHiddenToggleButton($buttonBar)) {
+            $buttonBar->addButton($button, ButtonBar::BUTTON_POSITION_LEFT, 3);
+        }
+
         // View
         if ($button = $this->makeViewButton($buttonBar, $request)) {
             $buttonBar->addButton($button, ButtonBar::BUTTON_POSITION_LEFT, 4);
@@ -657,6 +662,29 @@ final class PageEditController
             ->setTag('ve-show-empty-toggle')
             ->setLabel($this->getLanguageService()->sL('LLL:EXT:visual_editor/Resources/Private/Language/locallang_mod.xlf:showEmpty'))
             ->setIcon($this->iconFactory->getIcon('actions-hyphen', IconSize::SMALL))
+            ->setShowLabelText(true);
+    }
+
+    private function makeShowHiddenToggleButton(ButtonBar $buttonBar): ?ButtonInterface
+    {
+        if (
+            $this->pageRecord->getVersionInfo()?->getState() === VersionState::DELETE_PLACEHOLDER
+        ) {
+            return null;
+        }
+
+        $previewUriBuilder = PreviewUriBuilder::create($this->pageRecord->getRawRecord()->toArray());
+        if (!$previewUriBuilder->isPreviewable()) {
+            return null;
+        }
+
+
+        $button = $buttonBar->makeButton(GenericButton::class);
+        assert($button instanceof GenericButton);
+        return $button
+            ->setTag('ve-show-hidden-toggle')
+            ->setLabel($this->getLanguageService()->sL('LLL:EXT:visual_editor/Resources/Private/Language/locallang_mod.xlf:showHidden'))
+            ->setIcon($this->iconFactory->getIcon('actions-toggle-on', IconSize::SMALL))
             ->setShowLabelText(true);
     }
 

--- a/Resources/Private/Language/de.locallang_mod.xlf
+++ b/Resources/Private/Language/de.locallang_mod.xlf
@@ -18,6 +18,9 @@
       <trans-unit id="showEmpty">
         <target>Leere zeigen</target>
       </trans-unit>
+      <trans-unit id="showHidden">
+        <target>Ausgeblendete zeigen</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -18,6 +18,9 @@
       <trans-unit id="showEmpty">
         <source>Show empty</source>
       </trans-unit>
+      <trans-unit id="showHidden">
+        <source>Show hidden</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Public/JavaScript/Backend/components/ve-show-hidden-toggle.js
+++ b/Resources/Public/JavaScript/Backend/components/ve-show-hidden-toggle.js
@@ -1,0 +1,85 @@
+import {html, LitElement} from 'lit';
+import {sendMessage} from '@typo3/visual-editor/Shared/iframe-messaging';
+import {showHiddenActive} from '@typo3/visual-editor/Shared/local-stores';
+
+/**
+ * @extends {HTMLElement}
+ */
+export class VeShowHiddenToggle extends LitElement {
+  static properties = {
+    active: {type: Boolean, reflect: true,},
+    label: {type: String,},
+  };
+
+  createRenderRoot() {
+    // Disable shadow DOM
+    return this;
+  }
+
+  constructor() {
+    super();
+
+    this.label = this.innerText;
+    this.innerHTML = '';
+    this.active = showHiddenActive.get();
+    sendMessage('showHidden', this.active);
+    this.onShowHiddenChange = this.#onShowHiddenChange.bind(this);
+    this.onClick = this.#onClick.bind(this);
+    this.onKeydown = this.#onKeydown.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    showHiddenActive.addEventListener('change', this.onShowHiddenChange);
+    this.addEventListener('click', this.onClick);
+    this.addEventListener('keydown', this.onKeydown);
+  }
+
+  disconnectedCallback() {
+    showHiddenActive.removeEventListener('change', this.onShowHiddenChange);
+    this.removeEventListener('click', this.onClick);
+    this.removeEventListener('keydown', this.onKeydown);
+
+    super.disconnectedCallback();
+  }
+
+  willUpdate(changedProperties) {
+    this.classList.toggle('btn-primary', this.active);
+    this.classList.toggle('active', this.active);
+    this.classList.toggle('btn-default', !this.active);
+    this.setAttribute('role', 'switch');
+    this.setAttribute('aria-checked', String(this.active));
+    this.setAttribute('aria-label', this.label);
+    this.tabIndex = 0;
+  }
+
+  render() {
+    return html`
+      <typo3-backend-icon identifier="${this.active ? 'actions-toggle-on' : 'actions-toggle-off'}" size="small"></typo3-backend-icon>
+      ${this.label}
+    `;
+  }
+
+  #onShowHiddenChange() {
+    this.active = showHiddenActive.get();
+  }
+
+  #onClick(e) {
+    e.preventDefault();
+
+    this.active = !this.active;
+    showHiddenActive.set(this.active);
+    sendMessage('showHidden', this.active);
+  }
+
+  #onKeydown(e) {
+    if (e.key !== 'Enter' && e.key !== ' ') {
+      return;
+    }
+    e.preventDefault();
+    this.#onClick(e);
+  }
+}
+
+customElements.define('ve-show-hidden-toggle', VeShowHiddenToggle);

--- a/Resources/Public/JavaScript/Backend/index.js
+++ b/Resources/Public/JavaScript/Backend/index.js
@@ -4,6 +4,7 @@ import '@typo3/visual-editor/Backend/components/ve-auto-save-toggle';
 import '@typo3/visual-editor/Backend/components/ve-backend-save-button';
 import '@typo3/visual-editor/Backend/components/ve-spotlight-toggle';
 import '@typo3/visual-editor/Backend/components/ve-show-empty-toggle';
+import '@typo3/visual-editor/Backend/components/ve-show-hidden-toggle';
 import {pageChanged} from '@typo3/visual-editor/Backend/page-changed';
 import {initializePageTreeSaveState} from '@typo3/visual-editor/Backend/initialize-page-tree-save-state';
 

--- a/Resources/Public/JavaScript/Frontend/components/should-hide-content-element.js
+++ b/Resources/Public/JavaScript/Frontend/components/should-hide-content-element.js
@@ -1,0 +1,21 @@
+/**
+ * Decides whether a content element should be visually hidden because the editor
+ * turned off "Show hidden".
+ *
+ * Elements with an unsaved change to their hidden field stay visible so the editor
+ * can still see and revert the change they just made.
+ *
+ * @param {{showHidden: boolean, isHidden: boolean, hasUnsavedHiddenChange: boolean}} params
+ * @returns {boolean}
+ */
+export function shouldHideContentElement({showHidden, isHidden, hasUnsavedHiddenChange}) {
+  if (showHidden || !isHidden) {
+    return false;
+  }
+
+  if (hasUnsavedHiddenChange) {
+    return false;
+  }
+
+  return true;
+}

--- a/Resources/Public/JavaScript/Frontend/components/should-hide-content-element.test.js
+++ b/Resources/Public/JavaScript/Frontend/components/should-hide-content-element.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {shouldHideContentElement} from './should-hide-content-element.js';
+
+test('hides a hidden element when "Show hidden" is off', () => {
+  assert.equal(shouldHideContentElement({showHidden: false, isHidden: true, hasUnsavedHiddenChange: false}), true);
+});
+
+test('shows a hidden element when "Show hidden" is on', () => {
+  assert.equal(shouldHideContentElement({showHidden: true, isHidden: true, hasUnsavedHiddenChange: false}), false);
+});
+
+test('never hides a visible element', () => {
+  assert.equal(shouldHideContentElement({showHidden: false, isHidden: false, hasUnsavedHiddenChange: false}), false);
+  assert.equal(shouldHideContentElement({showHidden: true, isHidden: false, hasUnsavedHiddenChange: false}), false);
+});
+
+test('keeps a hidden element visible while it has an unsaved hidden-field change', () => {
+  assert.equal(shouldHideContentElement({showHidden: false, isHidden: true, hasUnsavedHiddenChange: true}), false);
+});

--- a/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-content-element.js
@@ -7,6 +7,8 @@ import {dataHandlerStore} from '@typo3/visual-editor/Frontend/stores/data-handle
 import {calculateAllDebounced} from '@typo3/visual-editor/Frontend/auto-no-overlap';
 import {getAriaRole} from '@typo3/visual-editor/Frontend/get-aria-role';
 import {getAddAboveUidPid} from '@typo3/visual-editor/Frontend/components/add-above-target';
+import {shouldHideContentElement} from '@typo3/visual-editor/Frontend/components/should-hide-content-element';
+import {showHiddenActive} from '@typo3/visual-editor/Shared/local-stores';
 
 /**
  * @extends {HTMLElement}
@@ -26,6 +28,7 @@ export class VeContentElement extends LitElement {
     canModifyRecord: {type: Boolean},
     canBeMoved: {type: Boolean},
 
+    showHidden: {type: Boolean, state: true, attribute: false},
     isHovered: {type: Boolean, state: true, attribute: false},
     isFocusWithin: {type: Boolean, state: true, attribute: false},
     dragInProgress: {type: Boolean, state: true, attribute: false},
@@ -80,6 +83,8 @@ export class VeContentElement extends LitElement {
   constructor() {
     super();
     this.onDragInProgressChange = this.#onDragInProgressChange.bind(this);
+    this.onShowHiddenChange = this.#onShowHiddenChange.bind(this);
+    this.showHidden = showHiddenActive.get();
     this.isFocusWithin = false;
     this.addEventListener('mouseenter', () => {
       this.isHovered = true;
@@ -108,6 +113,7 @@ export class VeContentElement extends LitElement {
     super.connectedCallback();
 
     dragInProgressStore.addEventListener('change', this.onDragInProgressChange);
+    showHiddenActive.addEventListener('change', this.onShowHiddenChange);
 
     if (this.parentElement.tagName.toLowerCase() !== 've-content-area') {
       let message = 'parent of ve-content-element must be ve-content-area, found ' + this.parentElement.tagName.toLowerCase();
@@ -118,8 +124,13 @@ export class VeContentElement extends LitElement {
 
   disconnectedCallback() {
     dragInProgressStore.removeEventListener('change', this.onDragInProgressChange);
+    showHiddenActive.removeEventListener('change', this.onShowHiddenChange);
 
     super.disconnectedCallback();
+  }
+
+  #onShowHiddenChange() {
+    this.showHidden = showHiddenActive.get();
   }
 
   #onDragInProgressChange() {
@@ -134,6 +145,19 @@ export class VeContentElement extends LitElement {
 
   get hasContentAreaAsParent() {
     return this.parentElement.tagName.toLowerCase() === 've-content-area';
+  }
+
+  /**
+   * Whether this element should be visually hidden because the editor turned off
+   * "Show hidden".
+   * @return {boolean}
+   */
+  get hideBecauseHidden() {
+    return shouldHideContentElement({
+      showHidden: this.showHidden,
+      isHidden: this.isHidden,
+      hasUnsavedHiddenChange: !!this.hiddenFieldName && dataHandlerStore.hasChangedData(this.table, this.uid, this.hiddenFieldName),
+    });
   }
 
   /**
@@ -184,6 +208,14 @@ export class VeContentElement extends LitElement {
       element.appendChild(child.firstChild);
     }
     child.remove();
+  }
+
+  /**
+   * @param changedProperties {Map<PropertyKey, unknown>}
+   */
+  updated(changedProperties) {
+    // hide the whole element when "Show hidden" is off and this element is hidden
+    this.style.display = this.hideBecauseHidden ? 'none' : '';
   }
 
   render() {

--- a/Resources/Public/JavaScript/Shared/local-stores.js
+++ b/Resources/Public/JavaScript/Shared/local-stores.js
@@ -49,3 +49,4 @@ function localStore(key, defaultValue) {
 export const spotlightActive = localStore('ve-spotlight-active', false);
 export const autoSaveActive = localStore('ve-autosave-active', true);
 export const showEmptyActive = localStore('ve-show-empty-active', false);
+export const showHiddenActive = localStore('ve-show-hidden-active', true);


### PR DESCRIPTION
Adds a "Show hidden" button next to "Show empty" in the editor module that toggles the visibility of currently hidden (disabled) content elements in the edit view.

The state is kept in a new `showHiddenActive` local store (default on) and synced into the frontend iframe via the existing postMessage bridge. Each ve-content-element hides itself when the toggle is off, unless it has an unsaved change to its hidden field, so a just-toggled element stays visible until saved.

<img width="583" height="85" alt="2026-06-09 Ausgeblendete Anzeigen im Visual Editor" src="https://github.com/user-attachments/assets/f857e0b5-cec2-42ca-9bfd-2dd326d69f09" />
