### PR TITLE
[BUGFIX] Avoid duplicated plugin route arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.codex
 /.claude
 *.local.md
+/packages

--- a/Classes/Service/EditModeService.php
+++ b/Classes/Service/EditModeService.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
-use function array_merge_recursive;
+use function array_replace_recursive;
 use function method_exists;
 
 final readonly class EditModeService
@@ -281,14 +281,14 @@ if (window.parent === window && window.veInfo) {
     /**
      * @return array<string|array<string|array<mixed>>>
      */
-    private function getUsedArguments(ServerRequestInterface $request): array
+    public function getUsedArguments(ServerRequestInterface $request): array
     {
         $routing = $request->getAttribute('routing');
         if (!$routing instanceof PageArguments) {
             throw new RuntimeException('Could not determine current routing context', 1773230232);
         }
 
-        $usedArguments = array_merge_recursive(
+        $usedArguments = array_replace_recursive(
             $routing->getArguments(),
             $routing->getRouteArguments(),
         );

--- a/Tests/Unit/Service/EditModeServiceTest.php
+++ b/Tests/Unit/Service/EditModeServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\VisualEditor\Tests\Unit\Service;
+
+use PHPUnit\Framework\MockObject\Exception;
+use Generator;
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\VisualEditor\Service\EditModeService;
+
+final class EditModeServiceTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $arguments
+     * @param array<string, mixed> $routeArguments
+     * @param array<string, mixed> $expected
+     * @throws Exception
+     */
+    #[Test]
+    #[DataProvider('usedArgumentsDataProvider')]
+    public function getUsedArgumentsReplacesDuplicateRouteArguments(array $arguments, array $routeArguments, array $expected): void
+    {
+        $routing = $this->createStub(PageArguments::class);
+        $routing
+            ->method('getArguments')
+            ->willReturn($arguments);
+        $routing
+            ->method('getRouteArguments')
+            ->willReturn($routeArguments);
+
+        $request = (new ServerRequest('GET', '/news/detail'))->withAttribute('routing', $routing);
+
+        self::assertSame($expected, $this->createSubject()->getUsedArguments($request));
+    }
+
+    /**
+     * @return Generator<string, array{arguments: array<mixed>, routeArguments: array<mixed>, expected: array<mixed>}>
+     */
+    public static function usedArgumentsDataProvider(): Generator
+    {
+        yield 'keeps duplicate plugin route arguments scalar' => [
+            'arguments' => [
+                'tx_news_pi1' => [
+                    'action' => 'detail',
+                    'controller' => 'News',
+                    'news' => '123',
+                ],
+                'cHash' => 'will-be-removed',
+                'editMode' => '1',
+            ],
+            'routeArguments' => [
+                'tx_news_pi1' => [
+                    'action' => 'detail',
+                    'controller' => 'News',
+                ],
+            ],
+            'expected' => [
+                'tx_news_pi1' => [
+                    'action' => 'detail',
+                    'controller' => 'News',
+                    'news' => '123',
+                ],
+            ],
+        ];
+
+        yield 'route arguments replace nested dynamic values' => [
+            'arguments' => [
+                'tx_news_pi1' => [
+                    'action' => 'list',
+                    'controller' => 'News',
+                ],
+                'category' => 'press',
+            ],
+            'routeArguments' => [
+                'tx_news_pi1' => [
+                    'action' => 'detail',
+                ],
+            ],
+            'expected' => [
+                'tx_news_pi1' => [
+                    'action' => 'detail',
+                    'controller' => 'News',
+                ],
+                'category' => 'press',
+            ],
+        ];
+
+        yield 'keeps repeated query argument values as list' => [
+            'arguments' => [
+                'filter' => [
+                    '123',
+                    '456',
+                ],
+            ],
+            'routeArguments' => [],
+            'expected' => [
+                'filter' => [
+                    '123',
+                    '456',
+                ],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function getUsedArgumentsThrowsExceptionIfRoutingIsMissing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1773230232);
+        $this->expectExceptionMessage('Could not determine current routing context');
+
+        $this->createSubject()->getUsedArguments(new ServerRequest('GET', '/'));
+    }
+
+    private function createSubject(): EditModeService
+    {
+        return (new ReflectionClass(EditModeService::class))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
Bug: When navigating to a page with an Extbase Route Enhancer (e.g. EXT:news detail page) in Visual Editor edit mode, reloading the page causes a TypeError because plugin arguments are duplicated as indexed arrays.

Root cause: getUsedArguments() calls array_merge_recursive() on getArguments() and getRouteArguments(). When both return the same plugin namespace keys (which is normal for pages with a Route Enhancer), array_merge_recursive() combines the values into arrays instead of overwriting them. This produces URLs like tx_news_pi1[action][0]=detail&tx_news_pi1[action][1]=detail, which Extbase cannot parse — it receives array where string is expected.

Fix: Replace array_merge_recursive() with array_replace_recursive() so that getRouteArguments() takes precedence and duplicates are eliminated.