### PR TITLE
[BUGFIX] Restore caret after editable text conversion

### DIFF
--- a/Resources/Public/JavaScript/Frontend/caret-helper.js
+++ b/Resources/Public/JavaScript/Frontend/caret-helper.js
@@ -1,0 +1,45 @@
+/**
+ * @param {Node} element
+ * @return {null|Selection}
+ */
+function getSelection(element) {
+  const root = element.getRootNode();
+
+  // in chromium, you need to use the shadowRoot instead of window ＞︿＜
+  return typeof root.getSelection === "function"
+    ? root.getSelection()
+    : window.getSelection();
+}
+
+/**
+ * @param {Node} element
+ * @return {number}
+ */
+export function getCaretOffset(element) {
+  const selection = getSelection(element);
+
+  if (!selection || selection.rangeCount === 0) {
+    return 0;
+  }
+
+  const range = selection.getRangeAt(0);
+  const preCaretRange = range.cloneRange();
+
+  preCaretRange.selectNodeContents(element);
+  preCaretRange.setEnd(range.endContainer, range.endOffset);
+
+  return preCaretRange.toString().length;
+}
+
+/**
+ * @param {Node} element
+ * @param {number} newCaretPosition
+ */
+export function setCaretPosition(element, newCaretPosition) {
+  const selection = getSelection(element);
+  const range = document.createRange();
+  range.setStart(element.firstChild || element, newCaretPosition);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -7,6 +7,7 @@ import '@typo3/visual-editor/Frontend/components/ve-icon';
 import '@typo3/visual-editor/Frontend/components/ve-validation-overlay';
 import {getEditValue, insertTextAtSelection} from '@typo3/visual-editor/Frontend/components/ve-editable-text/editing';
 import {getValidationIssues, normalizeValue} from '@typo3/visual-editor/Frontend/components/ve-editable-text/validation';
+import {getCaretOffset, setCaretPosition} from '@typo3/visual-editor/Frontend/caret-helper';
 
 /**
  * @extends {HTMLElement}
@@ -357,13 +358,16 @@ export class VeEditableText extends LitElement {
 
   /**
    * @param {string} value
+   * @return {boolean}
    */
   #setSlotText(value) {
     const element = this.#getSlot();
     // only change if something changes, otherwise the cursor position would reset on call
     if (element && element.innerText !== value) {
       element.innerText = value;
+      return true;
     }
+    return false;
   }
 
   #getSlotText() {
@@ -453,9 +457,20 @@ export class VeEditableText extends LitElement {
     this.#validateAndStore(this.#editableTextToStoredText(this.#getSlotText()));
   }
 
+
   #handleFocus() {
     this.focused = true;
-    this.#setSlotText(this.#storedTextToEditableText(this.value));
+
+    // in chromium, we need to wait until we can the caret position
+    requestAnimationFrame(() => {
+      const element = this.#getSlot();
+      const caret = getCaretOffset(element);
+      const newCaretPosition = this.#storedTextToEditableText(this.value.slice(0, caret)).length;
+
+      if (this.#setSlotText(this.#storedTextToEditableText(this.value))) {
+        setCaretPosition(element, newCaretPosition);
+      }
+    });
   }
 
   #handleBlur() {


### PR DESCRIPTION
Track the caret offset before converting stored text for editing and apply the matching position after the DOM update.

This keeps editors at the expected insertion point when focusing text fields.