### PR TITLE
[BUGFIX] Restore cHash exclusion for edit mode

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,3 +15,7 @@ ExtensionManagementUtility::addTypoScriptSetup("@import 'EXT:visual_editor/Confi
 if (!class_exists(ModifyRenderedContentAreaEvent::class)) {
     class_alias(V13_RenderContentAreaEvent::class, ModifyRenderedContentAreaEvent::class);
 }
+
+// exclude editMode from chash: If the parameter is present, the middleware already stops the normal rendering.
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] ??= [];
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'editMode';


### PR DESCRIPTION
Add `editMode` back to the cache hash excluded parameters.

The earlier cleanup missed configurations that continue to check cHash despite disabled caching. Since edit-mode requests are never cached, the flag must stay outside TYPO3 cHash validation.