### PR TITLE
[BUGFIX] Prevent editable text style collisions

### DIFF
--- a/Resources/Public/Css/editable.css
+++ b/Resources/Public/Css/editable.css
@@ -2,7 +2,7 @@
  * Custom styles for CKEditor to make it blend with the surrounding content.
  * TODO move this into the <ve-editable-rich-text> !!!
  */
-.ck-content.ck-content.ck-content {
+ve-editable-rich-text .ck-content.ck-content.ck-content {
   background: none !important;
   border: none !important;
   box-shadow: none !important;
@@ -14,7 +14,8 @@
 /**
   * Highlight the editable area on hover and focus:
  */
-.ck-content:hover, .ck-content:focus,
+ve-editable-rich-text .ck-content:hover,
+ve-editable-rich-text .ck-content:focus,
 ve-editable-rich-text[highlighted] .ck-content,
 ve-editable-rich-text[empty] .ck-content {
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.50) inset !important;
@@ -29,7 +30,7 @@ ve-editable-rich-text[changed] .ck-content {
 /**
   * (for now): Simulate InlineEditor of CKEditor
  */
-.ck-editor__top {
+ve-editable-rich-text .ck-editor__top {
   display: none;
   position: absolute !important;
   bottom: 100%; /* position it over the element */
@@ -43,17 +44,17 @@ ve-editable-rich-text[changed] .ck-content {
   }
 }
 
-.ck-content {
+ve-editable-rich-text .ck-content {
   /*color: var(--ck-content-font-color); !* TODO fix this if color is white we want to use white *!*/
 }
 
 /* hide placeholder if focused */
-.ck.ck-editor__editable.ck-focused > .ck-placeholder::before,
-.ck.ck-editor__editable.ck-focused .ck-placeholder::before {
+ve-editable-rich-text .ck.ck-editor__editable.ck-focused > .ck-placeholder::before,
+ve-editable-rich-text .ck.ck-editor__editable.ck-focused .ck-placeholder::before {
   display: none;
 }
 
-.ck-placeholder {
+ve-editable-rich-text .ck-placeholder {
   font-style: italic;
 }
 

--- a/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
+++ b/Resources/Public/JavaScript/Frontend/components/ve-editable-text.js
@@ -199,7 +199,7 @@ export class VeEditableText extends LitElement {
     const fieldLabel = this.name || this.title || this.field || this.placeholder;
     const ariaLabel = lll('editable.title', fieldLabel);
 
-    this.classList.toggle('block', !shouldBeInline);
+    this.classList.toggle('ve-block', !shouldBeInline);
 
     const slot = this.#getSlot();
     const showPlaceholder = !this.focused && !(slot?.innerText || this.value).length;
@@ -611,7 +611,7 @@ export class VeEditableText extends LitElement {
       --button-size: min(0.8em, 32px);
     }
 
-    :host(.block) {
+    :host(.ve-block) {
       display: block;
     }
 


### PR DESCRIPTION
Use component-specific selectors and class names for editable text elements.

This keeps site CSS from changing the editor layout and prevents editor styles from affecting unrelated CKEditor instances.

fixes #120