### PR TITLE
[TASK] Rename Visual Editor module tab

### DIFF
--- a/Resources/Private/Language/de.locallang_mod.xlf
+++ b/Resources/Private/Language/de.locallang_mod.xlf
@@ -10,7 +10,7 @@
         <target>Dieses Modul ermöglicht die Bearbeitung von Webseiten und deren Inhalten, wie sie von Besuchern gesehen werden.</target>
       </trans-unit>
       <trans-unit id="mlang_tabs_tab">
-        <target>Editor</target>
+        <target>Bearbeiten</target>
       </trans-unit>
       <trans-unit id="edit_page">
         <target>Seite bearbeiten</target>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -10,7 +10,7 @@
         <source>This module allows you to edit webpages, their content as seen by visitors.</source>
       </trans-unit>
       <trans-unit id="mlang_tabs_tab">
-        <source>Editor</source>
+        <source>Edit</source>
       </trans-unit>
       <trans-unit id="edit_page">
         <source>Edit page</source>


### PR DESCRIPTION
Use the clearer “Edit” label for the module tab and provide its German translation.